### PR TITLE
Melhorias em Menções, Brasileirão 2026 e Ajustes de Legenda

### DIFF
--- a/src/commands/raffle.ts
+++ b/src/commands/raffle.ts
@@ -67,7 +67,6 @@ export const command: StickerBotCommand = {
       `{ganhou |venceu |é o vencedor d}o {sorteio|concurso}${raffleName ? ' *' +
         raffleName + '*' : ''}! {🎉|🏆|🏅|🎖|🥇|⭐|✨}`
 
-        console.log(phrase)
     return await sendMessage(
       {
         text: spintax(phrase),

--- a/src/commands/raffle.ts
+++ b/src/commands/raffle.ts
@@ -1,4 +1,4 @@
-import { GroupMetadata, GroupParticipant, jidNormalizedUser } from '@whiskeysockets/baileys'
+import { GroupMetadata, GroupParticipant, jidEncode, jidNormalizedUser } from '@whiskeysockets/baileys'
 import path from 'path'
 
 import { getClient } from '../bot'
@@ -58,15 +58,20 @@ export const command: StickerBotCommand = {
     )
 
     const winner = getRandomItemFromArray(participants)
+    const winnerPhone = await getPhoneFromJid(winner.id)
+    const mentions = [winner.id]
+    if (winnerPhone) mentions.push(jidEncode(winnerPhone, 's.whatsapp.net'))
+
     const raffleName = getBodyWithoutCommand(body, command.needsPrefix, alias)
-    const phrase = `@${await getPhoneFromJid(winner.id)} {{meus |}parabéns|boa}! {Você|Tu|Vc} ` +
+    const phrase = `@${winnerPhone} {{meus |}parabéns|boa}! {Você|Tu|Vc} ` +
       `{ganhou |venceu |é o vencedor d}o {sorteio|concurso}${raffleName ? ' *' +
         raffleName + '*' : ''}! {🎉|🏆|🏅|🎖|🥇|⭐|✨}`
 
+        console.log(phrase)
     return await sendMessage(
       {
         text: spintax(phrase),
-        mentions: [winner.id]
+        mentions: Array.from(new Set(mentions))
       },
       message
     )

--- a/src/handlers/brasileirao.ts
+++ b/src/handlers/brasileirao.ts
@@ -1,5 +1,8 @@
 /* eslint-disable max-len */
-/* https://github.com/victorsouzaleal/brasileirao/blob/main/src/scrapper.js */
+/* https://github.com/victorsouzaleal/brasileirao */
+
+/* Como encontrar os ids das competições: */
+/* https://www.terra.com.br/esportes/futebol/brasileiro-serie-a/tabela/ - Inspecionar rede por 'idChampionship' */
 
 import axios from 'axios'
 import { JSDOM } from 'jsdom'
@@ -7,8 +10,8 @@ import { PartidaBrasileirao, ResultadoBrasileirao, RodadaBrasileirao, TimeBrasil
 import UserAgent from 'user-agents'
 
 export async function obterBrasileiraoA(rodadas: boolean = true): Promise<ResultadoBrasileirao> {
-  const URL_TABELA = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-light?idChampionship=1436&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
-  const URL_RODADAS = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-games-light?idChampionship=1436&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
+  const URL_TABELA = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-light?idChampionship=1456&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
+  const URL_RODADAS = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-games-light?idChampionship=1456&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
   const resultado: ResultadoBrasileirao = { tabela: await obterDadosTabela(URL_TABELA) }
   if (rodadas) {
     resultado.rodadas = await obterDadosRodadas(URL_RODADAS)
@@ -17,8 +20,8 @@ export async function obterBrasileiraoA(rodadas: boolean = true): Promise<Result
 }
 
 export async function obterBrasileiraoB(rodadas: boolean = true): Promise<ResultadoBrasileirao> {
-  const URL_TABELA = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-light?idChampionship=1438&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
-  const URL_RODADAS = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-games-light?idChampionship=1438&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
+  const URL_TABELA = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-light?idChampionship=1461&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
+  const URL_RODADAS = 'https://p1.trrsf.com/api/musa-soccer/ms-standings-games-light?idChampionship=1461&idPhase=&language=pt-BR&country=BR&nav=N&timezone=BR'
   const resultado: ResultadoBrasileirao = { tabela: await obterDadosTabela(URL_TABELA) }
   if (rodadas) {
     resultado.rodadas = await obterDadosRodadas(URL_RODADAS)

--- a/src/utils/baileysHelper.ts
+++ b/src/utils/baileysHelper.ts
@@ -377,11 +377,20 @@ export const sendLogToAdmins = async (text: string, mentions: string[] | undefin
   if (!bot.logsGroup) return
 
   const client = getClient()
+  const finalMentions = mentions ? [...mentions] : []
+
+  if (mentions) {
+    for (const mention of mentions) {
+      const phone = await getPhoneFromJid(mention)
+      if (phone) finalMentions.push(jidEncode(phone, 's.whatsapp.net'))
+    }
+  }
+
   return await client.sendMessage(
     bot.logsGroup,
     {
       text: text,
-      mentions: mentions
+      mentions: Array.from(new Set(finalMentions))
     },
     getMessageOptions(undefined, false)
   )

--- a/src/utils/baileysHelper.ts
+++ b/src/utils/baileysHelper.ts
@@ -291,14 +291,33 @@ export const logAction = (
 
 export const extractCaptionsFromBodyOrCaption = async (source: string) => {
   const client = getClient()
-  const botPhone = await getPhoneFromJid(client.user?.id)
-  const botMention = '@' + botPhone
-  const caption = source.replaceAll(botMention, '')// Removes the bot mention
+  const botId = client.user?.id
+  const botLid = client.user?.lid
+  const botPhone = await getPhoneFromJid(botId)
+
+  let cleanedSource = source
+
+  // Potential mentions to remove (based on JID, LID and Phone)
+  const mentionsToRemove = new Set<string>()
+  if (botPhone) mentionsToRemove.add('@' + botPhone)
+
+  const idUser = botId ? jidDecode(botId)?.user : undefined
+  if (idUser) mentionsToRemove.add('@' + idUser)
+
+  const lidUser = botLid ? jidDecode(botLid)?.user : undefined
+  if (lidUser) mentionsToRemove.add('@' + lidUser)
+
+  for (const mention of mentionsToRemove) {
+    cleanedSource = cleanedSource.replaceAll(mention, '')
+  }
+
+  const caption = cleanedSource
     .replaceAll('\n', '')
-    .split(';')// Line splitter. ex: `Top text;Bottom text`
+    .split(';') // Line splitter. ex: `Top text;Bottom text`
     .map(phrase => phrase.trim())
-    .filter(phrase => phrase.length > 0)// Removes empty strings
+    .filter(phrase => phrase.length > 0) // Removes empty strings
     .slice(0, 2)
+
   return caption
 }
 

--- a/src/utils/misc.ts
+++ b/src/utils/misc.ts
@@ -133,8 +133,8 @@ export const getTempFilePath = (filename: string): string => {
 
 export const getRandomFile = (dir: string): string => {
   const files = fs.readdirSync(dir)
-  const randomIndex = Math.floor(Math.random() * files.length)
-  return path.join(dir, files[randomIndex])
+  const file = getRandomItemFromArray(files)
+  return path.join(dir, file)
 }
 
 export const getRandomInt = (min: number, max: number): number => {


### PR DESCRIPTION
## 📝 Descrição
Esta branch consolida correções críticas relacionadas à migração para o Baileys v7, especificamente no tratamento de **LIDs** (IDs vinculados) e **JIDs** de telefone para menções. Além disso, atualiza as integrações com esportes para a temporada 2026 e realiza refatorações pontuais no código.

## 🚀 Principais Mudanças

### 1. Robustez em Menções (JID/LID/Phone)
- **Correção no Sorteio ([raffle.ts](cci:7://file:///d:/Backup%2001-04-2025/Desktop/projetos%20em%20andamento/git/stickerbot/src/commands/raffle.ts:0:0-0:0)):** Resolvido o problema onde o ganhador era mencionado pelo número puro em vez do nome do contato. Agora o bot resolve o telefone a partir do ID (mesmo sendo LID) e inclui ambos no array de `mentions`.
- **Melhoria Global de Logs ([baileysHelper.ts](cci:7://file:///d:/Backup%2001-04-2025/Desktop/projetos%20em%20andamento/git/stickerbot/src/utils/baileysHelper.ts:0:0-0:0)):** A função [sendLogToAdmins](cci:1://file:///d:/Backup%2001-04-2025/Desktop/projetos%20em%20andamento/git/stickerbot/src/utils/baileysHelper.ts:375:0-396:1) agora resolve automaticamente os JIDs de telefone de qualquer ID passado. Isso garante que os logs de sistema (Ban, VIP, etc.) mostrem os nomes dos administradores corretamente.

### 2. Extração de Legendas em Memes
- **Suporte a LID/JID:** Atualizada a lógica de remoção da menção do bot ao criar figurinhas (memegen). O bot agora remove menções baseadas no JID real, LID e número de telefone, evitando que resquícios de texto como `@5581...` apareçam na figurinha final.

### 3. Atualização Esportiva (Brasileirão 2026)
- **Brasileirão Série A & B:** Atualização dos IDs das competições (`idChampionship`) para a temporada de 2026, garantindo o funcionamento contínuo do comando de tabela e rodadas.

### 4. Refatoração e Limpeza
- **[misc.ts](cci:7://file:///d:/Backup%2001-04-2025/Desktop/projetos%20em%20andamento/git/stickerbot/src/utils/misc.ts:0:0-0:0):** Refatoração da função [getRandomFile](cci:1://file:///d:/Backup%2001-04-2025/Desktop/projetos%20em%20andamento/git/stickerbot/src/utils/misc.ts:133:0-137:1) para utilizar o utilitário [getRandomItemFromArray](cci:1://file:///d:/Backup%2001-04-2025/Desktop/projetos%20em%20andamento/git/stickerbot/src/utils/misc.ts:124:0-126:1), reduzindo a duplicação de lógica de aleatoriedade.

## 🛠 Como Testar
1.  **Sorteio:** Execute `!sorteio` em um grupo. Verifique se a menção do vencedor aparece com o nome em azul (clicável).
2.  **Memes:** Envie uma imagem marcando o bot com um texto (ex: `@bot legenda`). Verifique se `@bot` foi removido corretamente.
3.  **Brasileirão:** Execute `!brasileirao a/b` e verifique se as informações retornadas correspondem aos dados atuais de 2026.
4.  **Logs:** Verifique no grupo de logs se as menções aos administradores que executaram comandos VIP/Ban estão aparecendo com nomes.

## 📸 Screenshots
<img width="607" height="136" alt="image" src="https://github.com/user-attachments/assets/5f7e95bc-82b1-463c-b08c-38056ef8e47f" />

<img width="292" height="677" alt="image" src="https://github.com/user-attachments/assets/ccc934e3-178c-4b79-80b8-0bf29b540a30" />