### PR TITLE
feat(ads): advertising system managed via !ads

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,15 @@ WA_SESSION_ID=stickerbot
 
 # Should the bot send warnings? ex: 'Wait x seconds to send the command again'
 SB_SEND_WARNINGS=true
+
+# Ads Config
+# The bot sends one ad (from the Ads table, managed via !ads) to the chat where
+# a sticker was just created, once every SB_ADS_EVERY stickers.
+SB_ADS_SYSTEM=false
+# Send 1 ad every N stickers created (global counter)
+SB_ADS_EVERY=10
+# Minimum seconds between ads in the same chat (anti-spam). 1800 = 30 min
+SB_ADS_CHAT_COOLDOWN=1800
 SB_PREFIXES=!;/
 SB_DONATION=pix@jrkrz.com
 SB_STICKERS=5

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -20,6 +20,7 @@ import qrcode from 'qrcode-terminal'
 import { makeInMemoryStore } from './utils/store'
 
 import { baileys, bot } from './config'
+import { loadAdsConfig } from './handlers/ads'
 import { handleSenderParticipation } from './handlers/community'
 import { addVip, getAllBannedUsers, getVips, initializeDB, isUserBanned, senderIsVip } from './handlers/db'
 import { initializeEmojiMix } from './handlers/emojiMix'
@@ -545,6 +546,7 @@ const stickerBot = async () => {
   await checkForUpdates()
 
   await initializeDB()
+  await loadAdsConfig()
   await initializeEmojiMix()
 
   connectToWhatsApp()

--- a/src/commands/ads.ts
+++ b/src/commands/ads.ts
@@ -1,0 +1,280 @@
+import { downloadMediaMessage, extractMessageContent, GroupMetadata } from '@whiskeysockets/baileys'
+import path from 'path'
+
+import {
+  addAd,
+  getAdById,
+  getAdsConfig,
+  getAllAds,
+  removeAd,
+  sendAdPreview,
+  setAdActive,
+  setAdsCooldown,
+  setAdsEvery,
+  setAdsSystem
+} from '../handlers/ads'
+import { getLogger } from '../handlers/logger'
+import { StickerBotCommand } from '../types/Command'
+import { WAMessageExtended } from '../types/Message'
+import {
+  getImageMessageFromContent,
+  getQuotedMessage,
+  react,
+  sendMessage
+} from '../utils/baileysHelper'
+import { checkCommand } from '../utils/commandValidator'
+import { emojis } from '../utils/emojis'
+import { capitalize, getRandomItemFromArray } from '../utils/misc'
+
+// Gets the logger
+const logger = getLogger()
+
+// Gets the extension of this file, to dynamically import '.ts' if in development and '.js' if in production
+const extension = __filename.endsWith('.js') ? '.js' : '.ts'
+
+// Gets the file name without the .ts/.js extension
+const commandName = capitalize(path.basename(__filename, extension))
+
+const usage = '📢 *Gerenciador de Anúncios*\n\n' +
+  '`!ads list` - lista os anúncios e a configuração atual\n' +
+  '`!ads add <texto>` - cadastra um anúncio (responda/legende uma imagem para incluí-la)\n' +
+  '`!ads del <id>` - remove um anúncio\n' +
+  '`!ads on <id>` / `!ads off <id>` - ativa/desativa um anúncio\n' +
+  '`!ads test` - envia um anúncio de teste neste chat\n\n' +
+  '*Configuração:*\n' +
+  '`!ads cada <N>` - envia 1 anúncio a cada N figurinhas\n' +
+  '`!ads cooldown <min>` - intervalo mínimo por chat, em minutos (0 = sem intervalo)\n' +
+  '`!ads sistema on` / `!ads sistema off` - liga/desliga o envio automático'
+
+// Formats the current ads config as a single line, reused in the list and in confirmations.
+const formatConfig = (): string => {
+  const cfg = getAdsConfig()
+  const sys = cfg.system ? '🟢 ligado' : '🔴 desligado'
+  const cd = cfg.cooldown >= 60 ? `${Math.round(cfg.cooldown / 60)} min` : `${cfg.cooldown}s`
+  return `⚙️ Sistema: ${sys} · 1 a cada *${cfg.every}* figurinhas · cooldown ${cd}/chat`
+}
+
+// Command settings:
+export const command: StickerBotCommand = {
+  name: commandName,
+  aliases: ['ads', 'anuncio', 'anuncios', 'propaganda'],
+  desc: 'Gerencia os anúncios enviados automaticamente pelo bot.',
+  example: 'add Conheça nosso VIP! Use !donate',
+  needsPrefix: true,
+  inMaintenance: false,
+  runInPrivate: true,
+  runInGroups: true,
+  onlyInBotGroup: false,
+  onlyBotAdmin: true,
+  onlyAdmin: false,
+  onlyVip: false,
+  botMustBeAdmin: false,
+  interval: 0,
+  limiter: {}, // do not touch this
+  run: async (
+    jid: string,
+    sender: string,
+    message: WAMessageExtended,
+    alias: string,
+    body: string,
+    group: GroupMetadata | undefined,
+    isBotAdmin: boolean,
+    isVip: boolean,
+    isGroupAdmin: boolean,
+    amAdmin: boolean
+  ) => {
+    const check = await checkCommand(jid, message, alias, group, isBotAdmin, isVip, isGroupAdmin, amAdmin, command)
+    if (!check) return
+
+    // Strip prefix + alias, preserving the rest of the text (newlines/spacing) for the ad content
+    const params = body
+      .slice(command.needsPrefix ? 1 : 0)
+      .replace(new RegExp(`^${alias}\\s*`, 'i'), '')
+
+    const parsed = params.match(/^(\S+)\s*([\s\S]*)$/)
+    const sub = (parsed?.[1] || '').toLowerCase()
+    const argText = (parsed?.[2] || '').trim()
+
+    try {
+      // List
+      if (sub === '' || sub === 'list' || sub === 'lista') {
+        const all = await getAllAds()
+        if (all.length === 0) {
+          return await sendMessage(
+            {
+              text: `📭 Nenhum anúncio cadastrado.\n${formatConfig()}\n\n` +
+                'Use `!ads add <texto>` para criar o primeiro.'
+            },
+            message
+          )
+        }
+        let text = `📢 *Anúncios cadastrados (${all.length}):*\n${formatConfig()}\n`
+        for (const ad of all) {
+          const status = ad.active ? '🟢' : '🔴'
+          const img = ad.imageBase64 ? '🖼️ ' : ''
+          const oneLine = ad.content.replace(/\n/g, ' ')
+          const preview = oneLine.length > 60 ? oneLine.slice(0, 60) + '…' : oneLine
+          let stats = `📤 ${ad.sentCount} ${ad.sentCount === 1 ? 'envio' : 'envios'}`
+          if (ad.lastSentAt) {
+            const when = new Date(ad.lastSentAt).toLocaleString('pt-BR', {
+              day: '2-digit',
+              month: '2-digit',
+              hour: '2-digit',
+              minute: '2-digit'
+            })
+            stats += ` · último: ${when}`
+          }
+          text += `\n*#${ad.id}* ${status} ${img}${preview}\n   ↳ ${stats}`
+        }
+        text += '\n\n_Use_ `!ads on/off <id>`, `!ads del <id>` _ou_ `!ads test`'
+        return await sendMessage({ text }, message)
+      }
+
+      // Add
+      if (sub === 'add' || sub === 'adicionar') {
+        // Look for an image in the quoted message or in the command message itself
+        const quotedMsg = getQuotedMessage(message)
+        const targetMessage = quotedMsg ? quotedMsg : message
+        const content = extractMessageContent(targetMessage.message)
+        const imageMsg = content ? getImageMessageFromContent(content) : undefined
+
+        let imageBase64: string | null = null
+        if (imageMsg) {
+          try {
+            const buffer = (await downloadMediaMessage(targetMessage, 'buffer', {})) as Buffer
+            imageBase64 = buffer.toString('base64')
+          } catch (error) {
+            logger.error(`[ADS] Failed to download image for ad: ${error}`)
+            return await sendMessage(
+              { text: '⚠ Não consegui baixar a imagem. Tente novamente.' },
+              message
+            )
+          }
+        }
+
+        if (!argText && !imageBase64) {
+          await react(message, getRandomItemFromArray(emojis.confused))
+          return await sendMessage(
+            {
+              text: '⚠ Informe o texto do anúncio.\n\n*Exemplos:*\n' +
+                '`!ads add Conheça nosso VIP! Use !donate`\n' +
+                '_ou envie/responda uma imagem com a legenda_ `!ads add <texto>`'
+            },
+            message
+          )
+        }
+
+        await addAd(argText, imageBase64)
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage(
+          { text: `✅ Anúncio cadastrado${imageBase64 ? ' com imagem' : ''}!\n\nUse \`!ads list\` para ver todos.` },
+          message
+        )
+      }
+
+      // Remove
+      if (['del', 'delete', 'remove', 'rm', 'remover', 'excluir'].includes(sub)) {
+        const id = parseInt(argText)
+        if (isNaN(id)) {
+          return await sendMessage({ text: '⚠ Informe o ID do anúncio. Ex: `!ads del 3`' }, message)
+        }
+        const ad = await getAdById(id)
+        if (!ad) {
+          return await sendMessage({ text: `⚠ Anúncio *#${id}* não encontrado.` }, message)
+        }
+        await removeAd(id)
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage({ text: `🗑️ Anúncio *#${id}* removido.` }, message)
+      }
+
+      // Activate / Deactivate
+      if (sub === 'on' || sub === 'off' || sub === 'ativar' || sub === 'desativar') {
+        const id = parseInt(argText)
+        if (isNaN(id)) {
+          return await sendMessage({ text: '⚠ Informe o ID do anúncio. Ex: `!ads on 3`' }, message)
+        }
+        const ad = await getAdById(id)
+        if (!ad) {
+          return await sendMessage({ text: `⚠ Anúncio *#${id}* não encontrado.` }, message)
+        }
+        const activate = sub === 'on' || sub === 'ativar'
+        await setAdActive(id, activate)
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage(
+          { text: `${activate ? '🟢' : '🔴'} Anúncio *#${id}* ${activate ? 'ativado' : 'desativado'}.` },
+          message
+        )
+      }
+
+      // Test (sends a random active ad to the current chat, ignoring counter/cooldown)
+      if (sub === 'test' || sub === 'testar' || sub === 'preview') {
+        const sentId = await sendAdPreview(jid)
+        if (sentId === null) {
+          return await sendMessage(
+            { text: '📭 Nenhum anúncio *ativo* para testar. Cadastre com `!ads add` ou ative com `!ads on <id>`.' },
+            message
+          )
+        }
+        return undefined
+      }
+
+      // Config: frequency (1 ad every N stickers)
+      if (sub === 'cada' || sub === 'every' || sub === 'chance' || sub === 'freq') {
+        const n = parseInt(argText)
+        if (isNaN(n) || n < 1) {
+          return await sendMessage(
+            { text: '⚠ Informe um número ≥ 1. Ex: `!ads cada 10` (1 anúncio a cada 10 figurinhas).' },
+            message
+          )
+        }
+        await setAdsEvery(n)
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage(
+          { text: `✅ Frequência: 1 anúncio a cada *${n}* figurinhas.\n\n${formatConfig()}` },
+          message
+        )
+      }
+
+      // Config: per-chat cooldown (input in minutes, stored in seconds)
+      if (sub === 'cooldown' || sub === 'intervalo') {
+        const minutes = parseInt(argText)
+        if (isNaN(minutes) || minutes < 0) {
+          return await sendMessage(
+            { text: '⚠ Informe os minutos (≥ 0). Ex: `!ads cooldown 30` (0 = sem intervalo).' },
+            message
+          )
+        }
+        await setAdsCooldown(minutes * 60)
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage(
+          { text: `✅ Cooldown por chat: *${minutes} min*.\n\n${formatConfig()}` },
+          message
+        )
+      }
+
+      // Config: turn the automatic ad system on/off
+      if (sub === 'system' || sub === 'sistema') {
+        const arg = argText.toLowerCase()
+        const on = ['on', 'ligar', 'ligado', 'true', '1'].includes(arg)
+        const off = ['off', 'desligar', 'desligado', 'false', '0'].includes(arg)
+        if (!on && !off) {
+          return await sendMessage({ text: '⚠ Use `!ads sistema on` ou `!ads sistema off`.' }, message)
+        }
+        await setAdsSystem(on)
+        await react(message, getRandomItemFromArray(emojis.success))
+        const label = on ? '🟢 ligado' : '🔴 desligado'
+        return await sendMessage(
+          { text: `Envio automático: *${label}*.\n\n${formatConfig()}` },
+          message
+        )
+      }
+
+      // Unknown subcommand
+      return await sendMessage({ text: usage }, message)
+    } catch (error) {
+      logger.error(`Error in ${commandName}: ${error}`)
+      await react(message, emojis.error)
+      return await sendMessage({ text: '⚠ Ocorreu um erro ao gerenciar os anúncios.' }, message)
+    }
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -70,7 +70,10 @@ export const bot = {
   dbUser: process.env.DB_USER || 'root',
   dbPassword: process.env.DB_PASSWORD || '',
   dbName: process.env.DB_NAME || 'stickerbot',
-  dbPort: parseInt(process.env.DB_PORT || '3306')
+  dbPort: parseInt(process.env.DB_PORT || '3306'),
+  adsSystem: JSON.parse(process.env.SB_ADS_SYSTEM || 'false') as boolean,
+  adsEvery: parseInt(process.env.SB_ADS_EVERY || '10'),
+  adsChatCooldown: parseInt(process.env.SB_ADS_CHAT_COOLDOWN || '1800')
 }
 
 // External APIs

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,4 +1,4 @@
-import { datetime, int, mysqlTable, tinyint, varchar } from 'drizzle-orm/mysql-core'
+import { datetime, int, longtext, mysqlTable, text, tinyint, varchar } from 'drizzle-orm/mysql-core'
 
 export const usage = mysqlTable('Usage', {
   type: varchar('type', { length: 191 }).primaryKey(),
@@ -13,4 +13,21 @@ export const vips = mysqlTable('Vips', {
 
 export const banned = mysqlTable('Banned', {
   user: varchar('user', { length: 191 }).primaryKey(),
+})
+
+export const ads = mysqlTable('Ads', {
+  id: int('id').primaryKey().autoincrement(),
+  content: text('content').notNull(),
+  imageBase64: longtext('imageBase64'),
+  active: tinyint('active').default(1).notNull(),
+  sentCount: int('sentCount').default(0).notNull(),
+  lastSentAt: datetime('lastSentAt'),
+  createdAt: datetime('createdAt').notNull(),
+  updatedAt: datetime('updatedAt').notNull(),
+})
+
+// Generic runtime key/value config (e.g. ads.every, ads.cooldown, ads.system).
+export const settings = mysqlTable('Settings', {
+  key: varchar('key', { length: 191 }).primaryKey(),
+  value: text('value').notNull(),
 })

--- a/src/handlers/ads.ts
+++ b/src/handlers/ads.ts
@@ -1,0 +1,206 @@
+import { eq, sql } from 'drizzle-orm'
+
+import { getClient } from '../bot'
+import { bot } from '../config'
+import { ads } from '../db/schema'
+import { spintax } from '../utils/misc'
+import { db, getSetting, setSetting } from './db'
+import { getLogger } from './logger'
+
+const logger = getLogger()
+
+type AdRow = typeof ads.$inferSelect
+
+// Global counter of stickers created since the last ad was sent.
+// In-memory on purpose: resetting on restart is harmless for ads.
+let stickerCounter = 0
+// Timestamp (ms) of the last ad sent per chat, to enforce a cooldown.
+const lastAdByChat = new Map<string, number>()
+// In-flight guard: a single synchronous flag that stops a burst of concurrent stickers
+// from each crossing the counter threshold and dispatching duplicate ads.
+let dispatching = false
+
+// Effective runtime config, seeded from ENV and overridable via commands (persisted in the
+// Settings table). Cached in memory so maybeSendAd never touches the DB to read config.
+let adsEvery = bot.adsEvery
+let adsCooldown = bot.adsChatCooldown
+let adsSystemOn = bot.adsSystem
+
+const SETTING_EVERY = 'ads.every'
+const SETTING_COOLDOWN = 'ads.cooldown'
+const SETTING_SYSTEM = 'ads.system'
+
+// Loads persisted ads config from the DB into the in-memory cache. Called once at boot.
+// Missing keys keep their ENV-seeded defaults (ENV acts as the fallback).
+export const loadAdsConfig = async (): Promise<void> => {
+  try {
+    const every = await getSetting(SETTING_EVERY)
+    const cooldown = await getSetting(SETTING_COOLDOWN)
+    const system = await getSetting(SETTING_SYSTEM)
+    if (every !== null) {
+      const n = parseInt(every)
+      if (!isNaN(n) && n > 0) adsEvery = n
+    }
+    if (cooldown !== null) {
+      const n = parseInt(cooldown)
+      if (!isNaN(n) && n >= 0) adsCooldown = n
+    }
+    if (system !== null) adsSystemOn = system === 'true'
+    logger.info(`[ADS] Config: every=${adsEvery} cooldown=${adsCooldown}s system=${adsSystemOn}`)
+  } catch (error) {
+    logger.error(`[ADS] Failed to load config, using ENV defaults: ${error}`)
+  }
+}
+
+// Current effective config, for display by the !ads command.
+export const getAdsConfig = () => ({
+  every: adsEvery,
+  cooldown: adsCooldown,
+  system: adsSystemOn
+})
+
+export const setAdsEvery = async (n: number): Promise<void> => {
+  adsEvery = n
+  await setSetting(SETTING_EVERY, String(n))
+}
+
+export const setAdsCooldown = async (seconds: number): Promise<void> => {
+  adsCooldown = seconds
+  await setSetting(SETTING_COOLDOWN, String(seconds))
+}
+
+export const setAdsSystem = async (on: boolean): Promise<void> => {
+  adsSystemOn = on
+  await setSetting(SETTING_SYSTEM, on ? 'true' : 'false')
+}
+
+export const getAllAds = async (): Promise<AdRow[]> => {
+  return await db.select().from(ads).orderBy(ads.id)
+}
+
+export const getRandomActiveAd = async (): Promise<AdRow | null> => {
+  const rows = await db.select()
+    .from(ads)
+    .where(eq(ads.active, 1))
+    .orderBy(sql`RAND()`)
+    .limit(1)
+  return rows.length > 0 ? rows[0] : null
+}
+
+export const getAdById = async (id: number): Promise<AdRow | null> => {
+  const rows = await db.select().from(ads).where(eq(ads.id, id)).limit(1)
+  return rows.length > 0 ? rows[0] : null
+}
+
+export const addAd = async (content: string, imageBase64?: string | null): Promise<void> => {
+  const now = new Date()
+  await db.insert(ads).values({
+    content,
+    imageBase64: imageBase64 ?? null,
+    active: 1,
+    createdAt: now,
+    updatedAt: now
+  })
+}
+
+export const removeAd = async (id: number): Promise<void> => {
+  await db.delete(ads).where(eq(ads.id, id))
+}
+
+export const setAdActive = async (id: number, active: boolean): Promise<void> => {
+  await db.update(ads)
+    .set({
+      active: active ? 1 : 0,
+      updatedAt: new Date()
+    })
+    .where(eq(ads.id, id))
+}
+
+// Records one real dispatch: bumps the counter and stores the timestamp.
+// Test previews (!ads test) intentionally do NOT call this.
+export const incrementSentCount = async (id: number): Promise<void> => {
+  await db.update(ads)
+    .set({
+      sentCount: sql`${ads.sentCount} + 1`,
+      lastSentAt: new Date()
+    })
+    .where(eq(ads.id, id))
+}
+
+// Sends a given ad to a chat. Returns true if it was actually sent.
+const dispatchAd = async (jid: string, ad: AdRow): Promise<boolean> => {
+  const client = getClient()
+  if (!client) return false
+
+  const text = spintax(ad.content)
+
+  if (ad.imageBase64) {
+    const base64Data = ad.imageBase64.replace(/^data:image\/\w+;base64,/, '')
+    const imageBuffer = Buffer.from(base64Data, 'base64')
+    await client.sendMessage(jid, {
+      image: imageBuffer,
+      caption: text
+    })
+  } else {
+    await client.sendMessage(jid, { text })
+  }
+
+  return true
+}
+
+/**
+ * Sends a random active ad to a chat, ignoring counter and cooldown.
+ * Used by the !ads test command. Returns the sent ad id, or null if none.
+ */
+export const sendAdPreview = async (jid: string): Promise<number | null> => {
+  const ad = await getRandomActiveAd()
+  if (!ad) return null
+  const sent = await dispatchAd(jid, ad)
+  return sent ? ad.id : null
+}
+
+/**
+ * Called after each successful sticker creation. Sends an ad to the same chat
+ * once every `adsEvery` stickers, respecting a per-chat cooldown.
+ * Never throws: an ad failure must not break sticker creation.
+ */
+export const maybeSendAd = async (jid: string | null | undefined): Promise<void> => {
+  try {
+    if (!adsSystemOn || !jid) return
+
+    stickerCounter++
+    if (stickerCounter < adsEvery) return
+
+    // An ad is already being dispatched. Bail WITHOUT resetting the counter: this stops a
+    // burst of concurrent stickers from each crossing the threshold and sending duplicates.
+    if (dispatching) return
+
+    // If this chat got an ad recently, hold off WITHOUT resetting the counter, so the
+    // pending ad flows to the next sticker from an eligible chat.
+    const cooldownMs = adsCooldown * 1000
+    const lastAd = lastAdByChat.get(jid)
+    if (lastAd && Date.now() - lastAd < cooldownMs) return
+
+    // Claim the slot synchronously: there is no `await` between stickerCounter++ above and
+    // this assignment, so JS runs that whole block atomically (no interleaving possible).
+    dispatching = true
+    try {
+      const ad = await getRandomActiveAd()
+      if (!ad) return
+
+      const sent = await dispatchAd(jid, ad)
+      if (!sent) return
+
+      // Consume the credit only on a real send: reset the counter and start this chat's
+      // cooldown. On failure/no-ad the counter is left intact so the credit isn't lost.
+      stickerCounter = 0
+      lastAdByChat.set(jid, Date.now())
+      logger.info(`[ADS] Sent ad ID ${ad.id} to ${jid}`)
+      await incrementSentCount(ad.id)
+    } finally {
+      dispatching = false
+    }
+  } catch (error) {
+    logger.error(`[ADS] Error sending ad: ${error}`)
+  }
+}

--- a/src/handlers/db.ts
+++ b/src/handlers/db.ts
@@ -3,7 +3,7 @@ import { drizzle } from 'drizzle-orm/mysql2'
 import mysql from 'mysql2/promise'
 
 import { bot } from '../config'
-import { banned, usage, vips } from '../db/schema'
+import { banned, settings, usage, vips } from '../db/schema'
 import { getLogger } from './logger'
 
 const logger = getLogger()
@@ -45,6 +45,49 @@ export const initializeDB = async () => {
       \`user\` VARCHAR(191) PRIMARY KEY
     )
   `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS \`Ads\` (
+      \`id\` INT(11) NOT NULL AUTO_INCREMENT,
+      \`content\` TEXT NOT NULL,
+      \`imageBase64\` LONGTEXT,
+      \`active\` TINYINT(1) NOT NULL DEFAULT 1,
+      \`sentCount\` INT(11) NOT NULL DEFAULT 0,
+      \`lastSentAt\` DATETIME NULL,
+      \`createdAt\` DATETIME NOT NULL,
+      \`updatedAt\` DATETIME NOT NULL,
+      PRIMARY KEY (\`id\`)
+    )
+  `)
+
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS \`Settings\` (
+      \`key\` VARCHAR(191) NOT NULL,
+      \`value\` TEXT NOT NULL,
+      PRIMARY KEY (\`key\`)
+    )
+  `)
+
+  // Idempotent column migrations for tables created before a column existed.
+  // Uses information_schema so it works on both MySQL and MariaDB (no ADD COLUMN IF NOT EXISTS).
+  await ensureColumn('Ads', 'sentCount', 'INT(11) NOT NULL DEFAULT 0')
+  await ensureColumn('Ads', 'lastSentAt', 'DATETIME NULL')
+}
+
+/**
+ * Adds a column to a table only if it does not already exist.
+ * Cross-compatible with MySQL and MariaDB (avoids ADD COLUMN IF NOT EXISTS).
+ */
+const ensureColumn = async (table: string, column: string, definition: string): Promise<void> => {
+  const [rows] = await pool.query(
+    `SELECT COUNT(0) AS n FROM information_schema.COLUMNS
+     WHERE TABLE_SCHEMA = ? AND TABLE_NAME = ? AND COLUMN_NAME = ?`,
+    [bot.dbName, table, column]
+  )
+  // @ts-ignore
+  const exists = Number(rows[0].n) > 0
+  if (exists) return
+  await pool.query(`ALTER TABLE \`${table}\` ADD COLUMN \`${column}\` ${definition}`)
+  logger.info(`[DB] Migration: added column ${column} to ${table}`)
 }
 
 export const getCount = async (type: string) => {
@@ -57,6 +100,17 @@ export const addCount = async (type: string) => {
     .values({ type,
       count: 1 })
     .onDuplicateKeyUpdate({ set: { count: sql`${usage.count} + 1` } })
+}
+
+export const getSetting = async (key: string): Promise<string | null> => {
+  const rows = await db.select().from(settings).where(eq(settings.key, key)).limit(1)
+  return rows.length > 0 ? rows[0].value : null
+}
+
+export const setSetting = async (key: string, value: string): Promise<void> => {
+  await db.insert(settings)
+    .values({ key, value })
+    .onDuplicateKeyUpdate({ set: { value } })
 }
 
 export const getVips = async (getPermanent: boolean = true) => {
@@ -80,7 +134,7 @@ export const senderIsVip = async (sender: string): Promise<boolean> => {
     const result = await db.select({ expires: vips.expires })
       .from(vips)
       .where(sql`${vips.jid} = ${sender} AND (${vips.expires} >= CURRENT_TIMESTAMP OR ${vips.permanent} = 1)`)
-
+    
     return result.length > 0
   } catch (error) {
     logger.error(`Error checking if jid is a vip: ${error}`)
@@ -108,7 +162,7 @@ export const addVip = async (
   }
 
   const expires = new Date(baseDate.getTime() + (months * 30 * 24 * 60 * 60 * 1000))
-
+  
   await db.insert(vips)
     .values({
       jid,

--- a/src/handlers/sticker.ts
+++ b/src/handlers/sticker.ts
@@ -6,6 +6,7 @@ import { externalEndpoints, stickerMeta } from '../config'
 import { getMediaMessage, react, sendMessage } from '../utils/baileysHelper'
 import { emojis } from '../utils/emojis'
 import { getExtensionFromMimetype, getRandomItemFromArray, spintax } from '../utils/misc'
+import { maybeSendAd } from './ads'
 import { deleteUploadedFile, uploadFile } from './fileUploader'
 import { getLogger } from './logger'
 import { getCustomMemeUrl } from './memegen'
@@ -114,6 +115,9 @@ export const makeSticker = async (
 
     // react success
     if (needReact) await react(message, getRandomItemFromArray(emojis.success))
+
+    // maybe send an ad to the same chat (fire-and-forget, never breaks the sticker)
+    void maybeSendAd(message.key.remoteJid)
 
     // return result
     return result


### PR DESCRIPTION
## Summary

Adds an **advertising system** managed via `!ads`. After a sticker is created, the bot may send a registered ad to the same chat — once every N stickers, with a per-chat anti-spam cooldown.

> 🔗 **Stacked on #77** (`feat/db-drizzle`). Review/merge that first; this PR targets `feat/db-drizzle`, so its own diff shows only the ads changes.

## What changed

- **Tables**: `Ads` (content + optional base64 image, `active`, `sentCount`, `lastSentAt`) and a generic `Settings` key/value table; `getSetting` / `setSetting` helpers.
- **`handlers/ads.ts`**: global "1 ad every N stickers" counter + per-chat cooldown + an in-flight lock that prevents duplicate sends during sticker bursts; records `sentCount` / `lastSentAt`.
- **`commands/ads.ts`** (admin): `list`, `add` (text + optional image), `del`, `on`/`off`, `test`, plus runtime config (`cada N`, `cooldown`, `sistema on/off`).
- Config cached in memory (`loadAdsConfig` on boot), seeded from env (`SB_ADS_SYSTEM` / `SB_ADS_EVERY` / `SB_ADS_CHAT_COOLDOWN`) and overridable by command.
- `maybeSendAd` hooked into sticker creation (fire-and-forget; never breaks a sticker).
- Idempotent column migrations (`ensureColumn`) for `Ads`.

## How to use

- `!ads add Conheça nosso VIP!` (reply to / caption an image to attach it)
- `!ads list` · `!ads on/off <id>` · `!ads test`
- `!ads cada 15` · `!ads cooldown 30` · `!ads sistema on`

## Env

`SB_ADS_SYSTEM`, `SB_ADS_EVERY`, `SB_ADS_CHAT_COOLDOWN` (documented in `.env.example`).
