### PR TITLE
feat(lista): group signup list (pelada) with team draw

### DIFF
--- a/src/commands/lista.ts
+++ b/src/commands/lista.ts
@@ -1,0 +1,408 @@
+import { GroupMetadata, jidEncode, WAMessage } from '@whiskeysockets/baileys'
+import path from 'path'
+
+import {
+  createList,
+  drawTeams,
+  DrawResult,
+  EntryRow,
+  getActiveList,
+  getPresentCount,
+  joinList,
+  JoinResult,
+  leaveList,
+  markPresenceByJid,
+  markPresenceByPosition,
+  parseListTemplate,
+  removeByPosition,
+  renderList,
+  SECTION_GK,
+  SECTION_MAIN,
+  setListStatus
+} from '../handlers/lists'
+import { getLogger } from '../handlers/logger'
+import { StickerBotCommand } from '../types/Command'
+import { WAMessageExtended } from '../types/Message'
+import { getPhoneFromJid, react, sendMessage } from '../utils/baileysHelper'
+import { checkCommand } from '../utils/commandValidator'
+import { emojis } from '../utils/emojis'
+import { capitalize, getRandomItemFromArray } from '../utils/misc'
+
+// Gets the logger
+const logger = getLogger()
+
+// Gets the extension of this file, to dynamically import '.ts' if in development and '.js' if in production
+const extension = __filename.endsWith('.js') ? '.js' : '.ts'
+
+// Gets the file name without the .ts/.js extension
+const commandName = capitalize(path.basename(__filename, extension))
+
+const usage = '📋 *Listas (ex.: pelada)*\n\n' +
+  '`!lista` - mostra a lista atual\n' +
+  '`!lista eu` - você entra na linha\n' +
+  '`!lista gol` - você entra como goleiro\n' +
+  '`!lista add <nome>` - adiciona um convidado na linha\n' +
+  '`!lista gol <nome>` - adiciona um goleiro convidado\n' +
+  '`!lista presente` - marca a sua presença ✅\n' +
+  '`!lista presente <nº>` - marca presença por posição (`gol <nº>` p/ goleiro)\n' +
+  '`!lista falta <nº>` - desmarca presença\n' +
+  '`!lista sair` - você sai da lista\n\n' +
+  '*Admin do grupo:*\n' +
+  '`!lista criar` - cria a lista (responda/cole o modelo)\n' +
+  '`!lista nova` - recomeça a semana (mesma estrutura, vazia)\n' +
+  '`!lista remover <nº>` - remove da linha (`gol <nº>` p/ goleiro)\n' +
+  '`!lista fechar` / `!lista abrir` - tranca/destranca entradas\n' +
+  '`!lista sortear <N>` - sorteia times de N (só presentes)\n' +
+  '`!lista sortear <N> todos` - sorteia com todos da lista'
+
+const TEAM_EMOJIS = ['⚪', '🔵', '🔴', '🟢', '🟡', '🟣', '🟠', '⚫']
+
+// Reads the quoted message text directly from the command message's contextInfo.
+const getQuotedText = (message: WAMessage): string => {
+  const ctx = message.message?.extendedTextMessage?.contextInfo
+    || message.message?.ephemeralMessage?.message?.extendedTextMessage?.contextInfo
+  const q = ctx?.quotedMessage
+  if (!q) return ''
+  return q.conversation
+    || q.extendedTextMessage?.text
+    || q.imageMessage?.caption
+    || q.videoMessage?.caption
+    || ''
+}
+
+// A name argument means "add this person as a guest" (no linked account);
+// no argument means "the sender joins" (linked to their jid).
+const resolveJoiner = (argText: string, sender: string, senderName: string) => {
+  if (argText) return { name: argText, jid: null, addedBy: senderName }
+  return { name: senderName, jid: sender, addedBy: null }
+}
+
+// Short confirmation for a main-list join (used by !lista eu and !lista add).
+const replyJoin = async (
+  message: WAMessage,
+  res: JoinResult,
+  name: string,
+  mainCap: number
+): Promise<WAMessage | undefined> => {
+  if (res.status === 'dup') {
+    return await sendMessage({ text: 'ℹ️ Você já está na lista.' }, message)
+  }
+  await react(message, getRandomItemFromArray(emojis.success))
+  if (res.isReserva) {
+    return await sendMessage(
+      { text: `📋 *${name}* entrou nas reservas (${res.position - mainCap}º da fila).` },
+      message
+    )
+  }
+  return await sendMessage({ text: `✅ *${name}* entrou! (${res.position}/${mainCap})` }, message)
+}
+
+// Notifies (mentioning when possible) the reserve that was promoted into the list.
+const notifyPromotion = async (message: WAMessage, promoted: EntryRow): Promise<void> => {
+  if (promoted.jid) {
+    const phone = await getPhoneFromJid(promoted.jid)
+    if (phone) {
+      const mentions = [promoted.jid, jidEncode(phone, 's.whatsapp.net')]
+      await sendMessage(
+        {
+          text: `🔄 @${phone} subiu da reserva para a lista!`,
+          mentions: Array.from(new Set(mentions))
+        },
+        message
+      )
+      return
+    }
+  }
+  await sendMessage({ text: `🔄 *${promoted.name}* subiu da reserva para a lista!` }, message)
+}
+
+const renderDraw = (draw: DrawResult, size: number, all: boolean): string => {
+  const label = all ? 'jogadores' : 'presentes'
+  let out = `🎲 *Sorteio* — times de ${size} (${draw.confirmed} ${label})\n`
+  draw.teams!.forEach((team, i) => {
+    const emoji = TEAM_EMOJIS[i % TEAM_EMOJIS.length]
+    out += `\n${emoji} *Time ${i + 1}*`
+    team.players.forEach(p => {
+      out += `\n  • ${p.name}`
+    })
+    if (team.gk) out += `\n  🧤 ${team.gk.name}`
+  })
+  if (draw.leftover && draw.leftover.length > 0) {
+    out += '\n\n📋 *Fora do sorteio:* ' + draw.leftover.map(p => p.name).join(', ')
+  }
+  if (draw.gkLeftover && draw.gkLeftover.length > 0) {
+    out += '\n🧤 *Goleiros extras:* ' + draw.gkLeftover.map(p => p.name).join(', ')
+  }
+  return out
+}
+
+// Command settings:
+export const command: StickerBotCommand = {
+  name: commandName,
+  aliases: ['lista', 'listas', 'ls'],
+  desc: 'Cria e gerencia listas (ex.: pelada): entrar, sair, reservas e sorteio de times.',
+  example: 'eu',
+  needsPrefix: true,
+  inMaintenance: false,
+  runInPrivate: false,
+  runInGroups: true,
+  onlyInBotGroup: false,
+  onlyBotAdmin: false,
+  onlyAdmin: false, // open; admin subcommands are gated internally on isGroupAdmin
+  onlyVip: false,
+  botMustBeAdmin: false,
+  interval: 0,
+  limiter: {}, // do not touch this
+  run: async (
+    jid: string,
+    sender: string,
+    message: WAMessageExtended,
+    alias: string,
+    body: string,
+    group: GroupMetadata | undefined,
+    isBotAdmin: boolean,
+    isVip: boolean,
+    isGroupAdmin: boolean,
+    amAdmin: boolean
+  ) => {
+    const check = await checkCommand(jid, message, alias, group, isBotAdmin, isVip, isGroupAdmin, amAdmin, command)
+    if (!check) return
+
+    const params = body
+      .slice(command.needsPrefix ? 1 : 0)
+      .replace(new RegExp(`^${alias}\\s*`, 'i'), '')
+    const parsed = params.match(/^(\S+)\s*([\s\S]*)$/)
+    const sub = (parsed?.[1] || '').toLowerCase()
+    const argText = (parsed?.[2] || '').trim()
+
+    const senderName = message.pushName || 'Jogador'
+
+    const requireAdmin = async (): Promise<boolean> => {
+      if (!isGroupAdmin) {
+        await sendMessage({ text: `⚠ Só *administradores do grupo* podem usar \`!lista ${sub}\`.` }, message)
+        return false
+      }
+      return true
+    }
+
+    try {
+      // Create a list from a pasted/quoted model (admin)
+      if (sub === 'criar' || sub === 'create') {
+        if (!await requireAdmin()) return
+        const modelText = getQuotedText(message) || argText
+        if (!modelText.trim()) {
+          return await sendMessage(
+            {
+              text: '⚠ Responda à mensagem do modelo (ou cole junto) com `!lista criar`.\n' +
+                'O bot lê o título, o horário, as vagas e a seção de goleiros.'
+            },
+            message
+          )
+        }
+        const template = parseListTemplate(modelText)
+        if (!template) {
+          return await sendMessage(
+            { text: '⚠ Não entendi o modelo. Use o formato numerado (`1 - `, `2 - `, ...).' },
+            message
+          )
+        }
+        const created = await createList(jid, template, sender, true)
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage({ text: await renderList(created) }, message)
+      }
+
+      // Start a fresh week from the current structure (admin)
+      if (sub === 'nova' || sub === 'new' || sub === 'limpar') {
+        if (!await requireAdmin()) return
+        const active = await getActiveList(jid)
+        if (!active) {
+          return await sendMessage({ text: '⚠ Não há lista pra renovar. Crie com `!lista criar`.' }, message)
+        }
+        const created = await createList(
+          jid,
+          {
+            title: active.title,
+            subtitle: active.subtitle,
+            mainCap: active.mainCap,
+            gkLabel: active.gkLabel,
+            gkCap: active.gkCap,
+            mainNames: [],
+            gkNames: []
+          },
+          sender,
+          false
+        )
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage({ text: '🆕 Lista nova!\n\n' + await renderList(created) }, message)
+      }
+
+      // Everything below needs an active list
+      const list = await getActiveList(jid)
+      if (!list) {
+        return await sendMessage(
+          { text: '📭 Nenhuma lista ativa. Um *admin do grupo* cria com `!lista criar`.' },
+          message
+        )
+      }
+
+      // Show
+      if (sub === '' || sub === 'ver' || sub === 'show' || sub === 'lista') {
+        return await sendMessage({ text: await renderList(list) }, message)
+      }
+
+      const isMutating = ['eu', 'entrar', 'vou', 'gol', 'goleiro', 'add', 'adicionar', 'sair', 'fora'].includes(sub)
+      if (isMutating && list.status === 'closed') {
+        return await sendMessage({ text: '🔒 A lista está *fechada* no momento.' }, message)
+      }
+
+      // Join the main list — sender if no name, guest if a name is given
+      if (sub === 'eu' || sub === 'entrar' || sub === 'vou') {
+        const j = resolveJoiner(argText, sender, senderName)
+        const res = await joinList(list, SECTION_MAIN, j.name, j.jid, j.addedBy)
+        return await replyJoin(message, res, j.name, list.mainCap)
+      }
+
+      // Join as goalkeeper — sender if no name, guest goalkeeper if a name is given
+      if (sub === 'gol' || sub === 'goleiro') {
+        const j = resolveJoiner(argText, sender, senderName)
+        const res = await joinList(list, SECTION_GK, j.name, j.jid, j.addedBy)
+        if (res.status === 'gk_full') {
+          return await sendMessage(
+            { text: `🧤 Goleiros lotado (${list.gkCap}/${list.gkCap}). Entre na linha com \`!lista eu\`.` },
+            message
+          )
+        }
+        if (res.status === 'dup') {
+          return await sendMessage({ text: 'ℹ️ Você já está na lista.' }, message)
+        }
+        await react(message, getRandomItemFromArray(emojis.success))
+        return await sendMessage({ text: `🧤 *${j.name}* entrou como goleiro! (${res.position}/${list.gkCap})` }, message)
+      }
+
+      // Add a guest to the main list
+      if (sub === 'add' || sub === 'adicionar') {
+        if (!argText) {
+          return await sendMessage({ text: '⚠ Informe o nome. Ex: `!lista add Primo do Bruno`' }, message)
+        }
+        const res = await joinList(list, SECTION_MAIN, argText, null, senderName)
+        return await replyJoin(message, res, argText, list.mainCap)
+      }
+
+      // Leave the list
+      if (sub === 'sair' || sub === 'fora') {
+        const res = await leaveList(list, sender)
+        if (!res.ok) {
+          return await sendMessage({ text: 'ℹ️ Você não está na lista.' }, message)
+        }
+        await react(message, getRandomItemFromArray(emojis.success))
+        if (res.promoted) await notifyPromotion(message, res.promoted)
+        return undefined
+      }
+
+      // Mark / unmark presence — self (no arg), by line position, or "gol <nº>".
+      // Anyone can mark (collaborative); works even when the list is closed.
+      if (sub === 'presente' || sub === 'cheguei' || sub === 'falta' || sub === 'ausente') {
+        const present = sub === 'presente' || sub === 'cheguei'
+        const gkMatch = argText.match(/^(gol|goleiro)\s+(\d+)$/i)
+        let affected: EntryRow | null = null
+        if (!argText) {
+          affected = await markPresenceByJid(list, sender, present)
+          if (!affected) {
+            return await sendMessage(
+              { text: 'ℹ️ Você não está na lista. Entre com `!lista eu` primeiro.' },
+              message
+            )
+          }
+        } else if (gkMatch) {
+          affected = await markPresenceByPosition(list, SECTION_GK, parseInt(gkMatch[2]), present)
+          if (!affected) {
+            return await sendMessage({ text: `⚠ Goleiro *${gkMatch[2]}* não encontrado.` }, message)
+          }
+        } else {
+          const n = parseInt(argText)
+          if (isNaN(n)) {
+            return await sendMessage(
+              { text: '⚠ Use `!lista presente`, `!lista presente <nº>` ou `!lista presente gol <nº>`.' },
+              message
+            )
+          }
+          affected = await markPresenceByPosition(list, SECTION_MAIN, n, present)
+          if (!affected) {
+            return await sendMessage({ text: `⚠ Posição *${n}* não encontrada.` }, message)
+          }
+        }
+        if (!affected) return
+        await react(message, getRandomItemFromArray(emojis.success))
+        const count = await getPresentCount(list)
+        const status = present ? `✅ presente (${count} no total)` : '⬜ ausente'
+        return await sendMessage({ text: `*${affected.name}* — ${status}.` }, message)
+      }
+
+      // Remove someone by position (admin) — line by default, "gol <nº>" for goalkeepers
+      if (sub === 'remover' || sub === 'remove' || sub === 'rm') {
+        if (!await requireAdmin()) return
+        const gkMatch = argText.match(/^(gol|goleiro)\s+(\d+)$/i)
+        const section = gkMatch ? SECTION_GK : SECTION_MAIN
+        const position = parseInt(gkMatch ? gkMatch[2] : argText)
+        if (isNaN(position)) {
+          return await sendMessage(
+            { text: '⚠ Informe a posição. Ex: `!lista remover 3` ou `!lista remover gol 1`.' },
+            message
+          )
+        }
+        const res = await removeByPosition(list, position, section)
+        if (!res.ok) {
+          const where = section === SECTION_GK ? 'nos goleiros' : 'na linha'
+          return await sendMessage({ text: `⚠ Posição *${position}* não encontrada ${where}.` }, message)
+        }
+        await react(message, getRandomItemFromArray(emojis.success))
+        if (res.promoted) await notifyPromotion(message, res.promoted)
+        return await sendMessage({ text: `🗑️ *${res.removed?.name}* removido.` }, message)
+      }
+
+      // Open / close the list (admin)
+      if (sub === 'fechar' || sub === 'close' || sub === 'abrir' || sub === 'open') {
+        if (!await requireAdmin()) return
+        const closing = sub === 'fechar' || sub === 'close'
+        await setListStatus(list.id, closing ? 'closed' : 'open')
+        return await sendMessage({ text: closing ? '🔒 Lista fechada.' : '🔓 Lista reaberta.' }, message)
+      }
+
+      // Draw teams (admin) — present-only by default, "todos" includes everyone
+      if (sub === 'sortear' || sub === 'sorteio' || sub === 'times') {
+        if (!await requireAdmin()) return
+        const tokens = argText.split(/\s+/).filter(Boolean)
+        const all = tokens.some(t => ['todos', 'todas', 'all', 'geral', 'tudo'].includes(t.toLowerCase()))
+        const sizeToken = tokens.find(t => /^\d+$/.test(t))
+        const size = sizeToken ? parseInt(sizeToken) : NaN
+        if (isNaN(size) || size < 1) {
+          return await sendMessage(
+            { text: '⚠ Informe o tamanho do time. Ex: `!lista sortear 5` ou `!lista sortear 5 todos`.' },
+            message
+          )
+        }
+        const draw = await drawTeams(list, size, !all)
+        if (!draw.ok) {
+          let text: string
+          if (draw.error === 'nopresence') {
+            text = '⚠ Ninguém marcou presença ainda. Marque com `!lista presente` ' +
+              `ou sorteie todos com \`!lista sortear ${size} todos\`.`
+          } else if (draw.error === 'few') {
+            text = `⚠ Jogadores ${all ? '' : 'presentes '}insuficientes para um time de ${size}.`
+          } else {
+            text = '⚠ Tamanho de time inválido.'
+          }
+          return await sendMessage({ text }, message)
+        }
+        return await sendMessage({ text: renderDraw(draw, size, all) }, message)
+      }
+
+      // Unknown subcommand
+      return await sendMessage({ text: usage }, message)
+    } catch (error) {
+      logger.error(`Error in ${commandName}: ${error}`)
+      await react(message, emojis.error)
+      return await sendMessage({ text: '⚠ Ocorreu um erro ao gerenciar a lista.' }, message)
+    }
+  }
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -31,3 +31,30 @@ export const settings = mysqlTable('Settings', {
   key: varchar('key', { length: 191 }).primaryKey(),
   value: text('value').notNull(),
 })
+
+// Group lists (e.g. pelada): one active (status 'open') list per group.
+export const lists = mysqlTable('Lists', {
+  id: int('id').primaryKey().autoincrement(),
+  groupJid: varchar('groupJid', { length: 255 }).notNull(),
+  title: text('title').notNull(),
+  subtitle: text('subtitle'),
+  mainCap: int('mainCap').notNull(),
+  gkLabel: varchar('gkLabel', { length: 255 }),
+  gkCap: int('gkCap').default(0).notNull(),
+  status: varchar('status', { length: 20 }).default('open').notNull(),
+  createdBy: varchar('createdBy', { length: 255 }),
+  createdAt: datetime('createdAt').notNull(),
+  updatedAt: datetime('updatedAt').notNull(),
+})
+
+// Entries of a list. Render order = insertion order (id). Reserves = 'main' rows beyond mainCap.
+export const listEntries = mysqlTable('ListEntries', {
+  id: int('id').primaryKey().autoincrement(),
+  listId: int('listId').notNull(),
+  section: varchar('section', { length: 10 }).notNull(), // 'main' | 'gk'
+  name: varchar('name', { length: 255 }).notNull(),
+  jid: varchar('jid', { length: 255 }), // null = guest (added by someone)
+  addedBy: varchar('addedBy', { length: 255 }), // display name of who added a guest
+  present: tinyint('present').default(0).notNull(),
+  createdAt: datetime('createdAt').notNull(),
+})

--- a/src/handlers/db.ts
+++ b/src/handlers/db.ts
@@ -66,11 +66,43 @@ export const initializeDB = async () => {
       PRIMARY KEY (\`key\`)
     )
   `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS \`Lists\` (
+      \`id\` INT(11) NOT NULL AUTO_INCREMENT,
+      \`groupJid\` VARCHAR(255) NOT NULL,
+      \`title\` TEXT NOT NULL,
+      \`subtitle\` TEXT,
+      \`mainCap\` INT(11) NOT NULL,
+      \`gkLabel\` VARCHAR(255),
+      \`gkCap\` INT(11) NOT NULL DEFAULT 0,
+      \`status\` VARCHAR(20) NOT NULL DEFAULT 'open',
+      \`createdBy\` VARCHAR(255),
+      \`createdAt\` DATETIME NOT NULL,
+      \`updatedAt\` DATETIME NOT NULL,
+      PRIMARY KEY (\`id\`),
+      KEY \`group_status\` (\`groupJid\`, \`status\`)
+    )
+  `)
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS \`ListEntries\` (
+      \`id\` INT(11) NOT NULL AUTO_INCREMENT,
+      \`listId\` INT(11) NOT NULL,
+      \`section\` VARCHAR(10) NOT NULL,
+      \`name\` VARCHAR(255) NOT NULL,
+      \`jid\` VARCHAR(255),
+      \`addedBy\` VARCHAR(255),
+      \`present\` TINYINT(1) NOT NULL DEFAULT 0,
+      \`createdAt\` DATETIME NOT NULL,
+      PRIMARY KEY (\`id\`),
+      KEY \`listId\` (\`listId\`)
+    )
+  `)
 
   // Idempotent column migrations for tables created before a column existed.
   // Uses information_schema so it works on both MySQL and MariaDB (no ADD COLUMN IF NOT EXISTS).
   await ensureColumn('Ads', 'sentCount', 'INT(11) NOT NULL DEFAULT 0')
   await ensureColumn('Ads', 'lastSentAt', 'DATETIME NULL')
+  await ensureColumn('ListEntries', 'present', 'TINYINT(1) NOT NULL DEFAULT 0')
 }
 
 /**

--- a/src/handlers/lists.ts
+++ b/src/handlers/lists.ts
@@ -1,0 +1,425 @@
+import { and, asc, desc, eq } from 'drizzle-orm'
+
+import { listEntries, lists } from '../db/schema'
+import { db } from './db'
+
+export type ListRow = typeof lists.$inferSelect
+export type EntryRow = typeof listEntries.$inferSelect
+
+export const SECTION_MAIN = 'main'
+export const SECTION_GK = 'gk'
+
+// ---------------------------------------------------------------------------
+// Template parsing — turns a pasted/quoted list into a structured template.
+// ---------------------------------------------------------------------------
+
+export interface ParsedTemplate {
+  title: string
+  subtitle: string | null
+  mainCap: number
+  gkLabel: string | null
+  gkCap: number
+  mainNames: string[]
+  gkNames: string[]
+}
+
+// Matches a numbered slot line: "1 - Fulano", "12 -", "3 . Beltrano", etc.
+const SLOT_RE = /^\s*(\d+)\s*[-–.)]\s*(.*)$/
+
+interface ParsedSection {
+  label: string | null
+  count: number
+  names: string[]
+}
+
+export const parseListTemplate = (raw: string): ParsedTemplate | null => {
+  const lines = raw.split('\n').map(l => l.replace(/\s+$/, ''))
+  let title = ''
+  const subtitleLines: string[] = []
+  const sections: ParsedSection[] = []
+  let current: ParsedSection | null = null
+  let seenSlot = false
+
+  for (const line of lines) {
+    const trimmed = line.trim()
+    if (trimmed === '') continue
+    const match = trimmed.match(SLOT_RE)
+    if (match) {
+      seenSlot = true
+      if (!current) {
+        current = { label: null, count: 0, names: [] }
+        sections.push(current)
+      }
+      current.count++
+      const name = match[2].trim()
+      if (name) current.names.push(name)
+    } else if (!seenSlot) {
+      if (!title) title = trimmed
+      else subtitleLines.push(trimmed)
+    } else {
+      // A header line after slots starts a new section (e.g. "🥅 Goleiros").
+      current = { label: trimmed, count: 0, names: [] }
+      sections.push(current)
+    }
+  }
+
+  if (!title || sections.length === 0) return null
+
+  const main = sections[0]
+  const gk = sections[1] || null
+  return {
+    title,
+    subtitle: subtitleLines.length ? subtitleLines.join('\n') : null,
+    mainCap: main.count,
+    gkLabel: gk ? gk.label : null,
+    gkCap: gk ? gk.count : 0,
+    mainNames: main.names,
+    gkNames: gk ? gk.names : []
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Queries
+// ---------------------------------------------------------------------------
+
+export const getActiveList = async (groupJid: string): Promise<ListRow | null> => {
+  const rows = await db.select()
+    .from(lists)
+    .where(and(eq(lists.groupJid, groupJid), eq(lists.status, 'open')))
+    .orderBy(desc(lists.id))
+    .limit(1)
+  return rows.length > 0 ? rows[0] : null
+}
+
+export const getEntries = async (listId: number): Promise<EntryRow[]> => {
+  return await db.select()
+    .from(listEntries)
+    .where(eq(listEntries.listId, listId))
+    .orderBy(asc(listEntries.id))
+}
+
+// ---------------------------------------------------------------------------
+// Mutations
+// ---------------------------------------------------------------------------
+
+const buildImportedEntry = (listId: number, section: string, name: string) => ({
+  listId,
+  section,
+  name,
+  jid: null,
+  addedBy: null,
+  createdAt: new Date()
+})
+
+// Creates a new active list for the group (closing any previous open one).
+// When importNames is true, the names present in the template seed the entries.
+export const createList = async (
+  groupJid: string,
+  template: ParsedTemplate,
+  createdBy: string | null,
+  importNames: boolean
+): Promise<ListRow> => {
+  const now = new Date()
+  await db.update(lists)
+    .set({
+      status: 'closed',
+      updatedAt: now
+    })
+    .where(and(eq(lists.groupJid, groupJid), eq(lists.status, 'open')))
+
+  await db.insert(lists).values({
+    groupJid,
+    title: template.title,
+    subtitle: template.subtitle,
+    mainCap: template.mainCap,
+    gkLabel: template.gkLabel,
+    gkCap: template.gkCap,
+    status: 'open',
+    createdBy,
+    createdAt: now,
+    updatedAt: now
+  })
+
+  const list = await getActiveList(groupJid)
+  if (!list) throw new Error('Failed to create list')
+
+  if (importNames) {
+    const rows = [
+      ...template.mainNames.map(name => buildImportedEntry(list.id, SECTION_MAIN, name)),
+      ...template.gkNames.map(name => buildImportedEntry(list.id, SECTION_GK, name))
+    ]
+    if (rows.length > 0) await db.insert(listEntries).values(rows)
+  }
+
+  return list
+}
+
+export const setListStatus = async (listId: number, status: string): Promise<void> => {
+  await db.update(lists)
+    .set({
+      status,
+      updatedAt: new Date()
+    })
+    .where(eq(lists.id, listId))
+}
+
+const sectionRank = (entries: EntryRow[], entry: EntryRow): number => {
+  return entries.filter(e => e.section === entry.section).findIndex(e => e.id === entry.id) + 1
+}
+
+export interface JoinResult {
+  status: 'ok' | 'dup' | 'gk_full'
+  position: number
+  isReserva: boolean
+}
+
+export const joinList = async (
+  list: ListRow,
+  section: string,
+  name: string,
+  jid: string | null,
+  addedBy: string | null
+): Promise<JoinResult> => {
+  const entries = await getEntries(list.id)
+
+  if (jid) {
+    const existing = entries.find(e => e.jid === jid)
+    if (existing) {
+      const rank = sectionRank(entries, existing)
+      return {
+        status: 'dup',
+        position: rank,
+        isReserva: existing.section === SECTION_MAIN && rank > list.mainCap
+      }
+    }
+  }
+
+  if (section === SECTION_GK) {
+    const gkCount = entries.filter(e => e.section === SECTION_GK).length
+    if (gkCount >= list.gkCap) return { status: 'gk_full', position: 0, isReserva: false }
+  }
+
+  await db.insert(listEntries).values({
+    listId: list.id,
+    section,
+    name,
+    jid: jid ?? null,
+    addedBy: addedBy ?? null,
+    createdAt: new Date()
+  })
+
+  const sectionCount = entries.filter(e => e.section === section).length + 1
+  const isReserva = section === SECTION_MAIN && sectionCount > list.mainCap
+  return { status: 'ok', position: sectionCount, isReserva }
+}
+
+// Deletes an entry and returns the reserve that gets promoted into the main
+// list (if removing this entry opened a playing spot), or null.
+const removeEntry = async (list: ListRow, entry: EntryRow, entries: EntryRow[]): Promise<EntryRow | null> => {
+  let promoted: EntryRow | null = null
+  if (entry.section === SECTION_MAIN) {
+    const main = entries.filter(e => e.section === SECTION_MAIN)
+    const index = main.findIndex(e => e.id === entry.id)
+    if (index >= 0 && index < list.mainCap && main.length > list.mainCap) {
+      promoted = main[list.mainCap]
+    }
+  }
+  await db.delete(listEntries).where(eq(listEntries.id, entry.id))
+  return promoted
+}
+
+export interface RemoveResult {
+  ok: boolean
+  removed?: EntryRow
+  promoted?: EntryRow | null
+}
+
+export const leaveList = async (list: ListRow, jid: string): Promise<RemoveResult> => {
+  const entries = await getEntries(list.id)
+  const mine = entries.find(e => e.jid === jid)
+  if (!mine) return { ok: false }
+  const promoted = await removeEntry(list, mine, entries)
+  return { ok: true, removed: mine, promoted }
+}
+
+export const removeByPosition = async (
+  list: ListRow,
+  position: number,
+  section: string = SECTION_MAIN
+): Promise<RemoveResult> => {
+  const entries = await getEntries(list.id)
+  const sectionEntries = entries.filter(e => e.section === section)
+  if (position < 1 || position > sectionEntries.length) return { ok: false }
+  const entry = sectionEntries[position - 1]
+  const promoted = await removeEntry(list, entry, entries)
+  return { ok: true, removed: entry, promoted }
+}
+
+// ---------------------------------------------------------------------------
+// Presence
+// ---------------------------------------------------------------------------
+
+const setEntryPresent = async (entryId: number, present: boolean): Promise<void> => {
+  await db.update(listEntries)
+    .set({ present: present ? 1 : 0 })
+    .where(eq(listEntries.id, entryId))
+}
+
+// Marks the sender's own entry (matched by jid). Returns the entry, or null if not on the list.
+export const markPresenceByJid = async (
+  list: ListRow,
+  jid: string,
+  present: boolean
+): Promise<EntryRow | null> => {
+  const entries = await getEntries(list.id)
+  const mine = entries.find(e => e.jid === jid)
+  if (!mine) return null
+  await setEntryPresent(mine.id, present)
+  return { ...mine, present: present ? 1 : 0 }
+}
+
+// Marks an entry by its display position within a section (handles guests).
+export const markPresenceByPosition = async (
+  list: ListRow,
+  section: string,
+  position: number,
+  present: boolean
+): Promise<EntryRow | null> => {
+  const entries = await getEntries(list.id)
+  const sectionEntries = entries.filter(e => e.section === section)
+  if (position < 1 || position > sectionEntries.length) return null
+  const entry = sectionEntries[position - 1]
+  await setEntryPresent(entry.id, present)
+  return { ...entry, present: present ? 1 : 0 }
+}
+
+// Count of present players among the playing line (1..mainCap) plus goalkeepers.
+export const getPresentCount = async (list: ListRow): Promise<number> => {
+  const entries = await getEntries(list.id)
+  const playing = entries.filter(e => e.section === SECTION_MAIN).slice(0, list.mainCap)
+  const gk = entries.filter(e => e.section === SECTION_GK)
+  return [...playing, ...gk].filter(e => e.present).length
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+const formatName = (entry: EntryRow): string => {
+  // Present players get a green check; member-added guests show who brought them.
+  const check = entry.present ? '✅ ' : ''
+  if (!entry.jid && entry.addedBy) return `${check}${entry.name} (convidado de ${entry.addedBy})`
+  return `${check}${entry.name}`
+}
+
+export const renderList = async (list: ListRow): Promise<string> => {
+  const entries = await getEntries(list.id)
+  const main = entries.filter(e => e.section === SECTION_MAIN)
+  const gk = entries.filter(e => e.section === SECTION_GK)
+
+  let out = list.title
+  if (list.subtitle) out += `\n${list.subtitle}`
+  out += '\n'
+
+  for (let i = 0; i < list.mainCap; i++) {
+    const entry = main[i]
+    out += `\n${i + 1} - ${entry ? formatName(entry) : ''}`
+  }
+
+  if (list.gkCap > 0) {
+    out += `\n\n${list.gkLabel || '🥅 Goleiros'}`
+    for (let i = 0; i < list.gkCap; i++) {
+      const entry = gk[i]
+      out += `\n${i + 1} - ${entry ? formatName(entry) : ''}`
+    }
+  }
+
+  const reservas = main.slice(list.mainCap)
+  if (reservas.length > 0) {
+    out += '\n\n📋 Reservas'
+    reservas.forEach((entry, i) => {
+      out += `\n${list.mainCap + i + 1} - ${formatName(entry)}`
+    })
+  }
+
+  const presentCount = [...main.slice(0, list.mainCap), ...gk].filter(e => e.present).length
+  if (presentCount > 0) out += `\n\n✅ ${presentCount} presente${presentCount > 1 ? 's' : ''}`
+
+  if (list.status === 'closed') out += '\n\n🔒 _Lista fechada_'
+  return out
+}
+
+// ---------------------------------------------------------------------------
+// Team draw
+// ---------------------------------------------------------------------------
+
+const shuffle = <T>(arr: T[]): T[] => {
+  for (let i = arr.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    const tmp = arr[i]
+    arr[i] = arr[j]
+    arr[j] = tmp
+  }
+  return arr
+}
+
+export interface Team {
+  players: EntryRow[]
+  gk: EntryRow | null
+}
+
+export interface DrawResult {
+  ok: boolean
+  error?: 'size' | 'few' | 'nopresence'
+  confirmed?: number
+  teams?: Team[]
+  leftover?: EntryRow[]
+  gkLeftover?: EntryRow[]
+}
+
+// Draws the line players (positions 1..mainCap, not reserves) into teams of
+// teamSize, distributing one goalkeeper per team. Leftovers are listed.
+// presentOnly (default) restricts the draw to players marked present.
+export const drawTeams = async (
+  list: ListRow,
+  teamSize: number,
+  presentOnly: boolean = true
+): Promise<DrawResult> => {
+  if (teamSize < 1) return { ok: false, error: 'size' }
+
+  const entries = await getEntries(list.id)
+  let confirmed = entries.filter(e => e.section === SECTION_MAIN).slice(0, list.mainCap)
+  let goalkeepers = entries.filter(e => e.section === SECTION_GK)
+  if (presentOnly) {
+    confirmed = confirmed.filter(e => e.present)
+    goalkeepers = goalkeepers.filter(e => e.present)
+  }
+
+  if (presentOnly && confirmed.length === 0) return { ok: false, error: 'nopresence' }
+  if (confirmed.length < teamSize) return { ok: false, error: 'few' }
+
+  const players = shuffle([...confirmed])
+  const numTeams = Math.floor(players.length / teamSize)
+  const teams: Team[] = []
+  for (let t = 0; t < numTeams; t++) {
+    teams.push({
+      players: players.slice(t * teamSize, (t + 1) * teamSize),
+      gk: null
+    })
+  }
+  const leftover = players.slice(numTeams * teamSize)
+
+  const shuffledGk = shuffle([...goalkeepers])
+  for (let t = 0; t < teams.length && t < shuffledGk.length; t++) {
+    teams[t].gk = shuffledGk[t]
+  }
+  const gkLeftover = shuffledGk.slice(teams.length)
+
+  return {
+    ok: true,
+    confirmed: confirmed.length,
+    teams,
+    leftover,
+    gkLeftover
+  }
+}


### PR DESCRIPTION
## Summary

Adds a bot-managed **group signup list** (e.g. *pelada*) via `!lista`, created from a pasted model, with waitlist, presence and a team draw.

> 🔗 **Stacked on #78** (`feat/ads`). This PR targets `feat/ads`, so its own diff shows only the list feature.

## What changed

- **Tables**: `Lists` (title, subtitle, capacities, status) and `ListEntries` (section, name, jid, addedBy, `present`) + idempotent `present` column migration.
- **`handlers/lists.ts`**: pasted-model template parser; one active list per group; auto-waitlist (reserves) with automatic promotion when a spot opens; goalkeeper section; low-spam rendering; team draw.
- **`commands/lista.ts`**:
  - Everyone: `!lista` (show), `!lista eu` / `!lista gol` (join self), `!lista add <nome>` / `!lista gol <nome>` (guest), `!lista sair`, `!lista presente [nº]` / `!lista falta [nº]` (presence ✅).
  - **Group admins only**: `criar` (reply/paste model), `nova`, `remover [gol] <nº>`, `fechar` / `abrir`, `sortear <N> [todos]`.

## Behavior notes

- With a name → adds that person as a guest; without a name → it's the sender.
- Reserves are numbered continuously and promote automatically.
- `sortear <N>` draws only players marked present (or everyone with `todos`), distributing one goalkeeper per team.
- Admin subcommands are gated on **group admin** (not bot admin).
