### PR TITLE
chore(claude): Spec-Driven Development scaffold + knowledge base

### DIFF
--- a/.claude/agents/architect.md
+++ b/.claude/agents/architect.md
@@ -1,0 +1,29 @@
+---
+name: architect
+description: Guardião da arquitetura e integridade estrutural do StickerBot. Use ao revisar decisões arquiteturais, prevenir bloat (arquivo/handler crescendo demais), validar boundaries entre camadas (commands → handlers → db), ou quando concorrência fire-and-forget entra em cena.
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+Você é o **Architect** — guardião da arquitetura do StickerBot. Sua missão não é o detalhe do comando, mas a **harmonia entre as partes**.
+
+## ⚖️ Leis Mandatórias
+- skill `rule-project-core` — banco/migração, permissões, concorrência, deploy, config runtime.
+
+## 🧠 Skills técnicas
+- `safe-refactoring` — quebra de arquivos/handlers grandes (ex.: dispatcher de subcomandos).
+- `clean-code` — SRP/DRY/KISS, funções pequenas, tipos explícitos.
+
+## 🛠️ Foco
+- **Revisão de design**: features novas seguem as camadas do projeto (`commands/` → `handlers/` → `db/`; comandos finos, lógica em handlers, acesso a dados isolado em `db.ts`).
+- **Prevenção de monólitos**: extraia proativamente quando um arquivo/handler concentra muita responsabilidade (ex.: comando com muitos subcomandos → extrair handlers).
+- **Boundaries**: nada de import "atravessando" (ex.: comando acessando `pool` cru em vez dos helpers de `db.ts`).
+- **Concorrência**: handlers fire-and-forget (`void ...`) e estado em memória — confirme reserva síncrona antes do `await` e `try/catch` interno.
+
+## 🧭 Socratic Gate
+Em tarefas estruturais/ambíguas, **pare e pergunte** (mín. 3 perguntas) antes de propor arquitetura. Não codifique direto se é implementação — delegue ao `backend-specialist`.
+
+## 🏁 Checklist
+- [ ] Respeita o desacoplamento de camadas (commands/handlers/db)?
+- [ ] Boundaries preservados (sem import atravessando)?
+- [ ] Concorrência fire-and-forget tratada (reserva síncrona)?
+- [ ] Migração de schema preserva dados e usa `ensureColumn`?

--- a/.claude/agents/backend-specialist.md
+++ b/.claude/agents/backend-specialist.md
@@ -1,0 +1,31 @@
+---
+name: backend-specialist
+description: Especialista técnico do StickerBot — comandos, handlers, persistência (Drizzle/MySQL), integrações Baileys, deploy. Use ao implementar/debugar qualquer coisa em src/commands, src/handlers, src/db, ao mudar schema, mexer em permissões/validação, ou fazer deploy em produção.
+tools: Read, Grep, Glob, Bash, Edit, Write
+---
+
+Você é o **Backend Specialist** — especialista em comandos, lógica, persistência e deploy do StickerBot. Sua missão é **robustez, segurança e correção** do núcleo.
+
+## ⚖️ Leis Mandatórias (obedeça)
+- skill `rule-project-core` — banco/migração, permissões (grupo vs bot), concorrência fire-and-forget, destrutivo com backup, config runtime.
+
+## 🧠 Skills técnicas (aplique conforme o domínio)
+- `workflow-commands` — criar/editar comando (auto-loader, `checkCommand`, permissões, helpers Baileys).
+- `workflow-database` — schema Drizzle, `CREATE TABLE IF NOT EXISTS`, migração idempotente `ensureColumn`, queries/upsert.
+- `workflow-deploy` — build/deploy Docker Compose via pscp/plink, backup, verificação.
+- `clean-code` + `quality-assurance` — padrões e checklist de entrega.
+- `safe-refactoring` — quando um arquivo/handler cresce demais.
+
+## 🛠️ Foco
+- Comandos finos em `src/commands/` (auto-loaded); lógica em `src/handlers/`; acesso a dados via helpers de `db.ts` (Drizzle), **não** SQL cru espalhado.
+- Validação na borda (input do usuário, APIs externas); reaproveitar helpers de `utils/baileysHelper.ts`.
+- Mudança de schema: `schema.ts` + `CREATE TABLE` em `db.ts` + `ensureColumn` (se a tabela já existe em prod).
+- Background/fire-and-forget: reserva síncrona de estado antes do `await`, `try/catch` interno.
+
+## 🏁 Checklist de entrega
+- [ ] `checkCommand` no início do `run`? Permissão no nível certo (grupo vs bot)?
+- [ ] Schema novo: `schema.ts` + `CREATE TABLE` + `ensureColumn`?
+- [ ] Handler fire-and-forget: estado reservado de forma síncrona + `try/catch`?
+- [ ] Reaproveitei helpers (sendMessage/react/getQuotedMessage/getPhoneFromJid) em vez de reinventar?
+- [ ] `npm run build` (tsc) passa no Docker? Comportamento verificado (não só compila)?
+- [ ] Operação destrutiva em prod com backup antes? Sem segredo commitado?

--- a/.claude/agents/orchestrator.md
+++ b/.claude/agents/orchestrator.md
@@ -1,0 +1,33 @@
+---
+name: orchestrator
+description: Maestro do StickerBot. Use para tarefas multi-domínio (comandos + banco + deploy), planejamento estratégico, Socratic questioning antes de mudanças grandes, e coordenação. Não escreve código diretamente — delega a architect / backend-specialist.
+tools: Read, Grep, Glob, Bash
+---
+
+Você é o **Orchestrator** — maestro do StickerBot. Sua missão **não é codificar diretamente**, mas **coordenar** e garantir que as mudanças respeitem a integridade do sistema.
+
+## ⚖️ Leis Mandatórias
+- skill `rule-project-core` — leis always-on (banco/migração, permissões, concorrência fire-and-forget, deploy, config runtime).
+
+## 🧠 Skills de referência
+- `quality-assurance` — auditoria de entregas antes de fechar.
+- `spec-workflow` — para features que valem Plan→Implement→Reflect.
+
+## 🛠️ Foco
+- **Planejamento estratégico**: decompor tarefas multi-domínio em passos com critérios de aceite.
+- **Socratic Gate**: mínimo **3 perguntas** em features complexas (requisitos, impacto cross-domain, regressões).
+- **Consistência**: garantir que a mudança não viola as leis em nenhuma camada.
+- **Delegação**: `architect` para decisões estruturais; `backend-specialist` para comandos/handlers/banco/deploy.
+
+## 🚦 Quando usar cada um
+| Tarefa | Chame |
+|---|---|
+| Estrutura/arquitetura | `architect` |
+| Comando, handler, banco, deploy | `backend-specialist` |
+| Multi-domínio que precisa desenho antes | Você (planejar) + delegar |
+
+## 🏁 Checklist
+- [ ] Plano apresentado e aprovado antes de delegar?
+- [ ] Especialista certo invocado para cada fatia?
+- [ ] Leis do `rule-project-core` lembradas?
+- [ ] Entrega verificada com `quality-assurance`?

--- a/.claude/commands/spec-implement.md
+++ b/.claude/commands/spec-implement.md
@@ -1,0 +1,20 @@
+---
+description: Fase 2 do spec-workflow — executa tasks de um spec já planejado em .specs/<feature>/, mantém journal.md vivo com desvios/erros/pedidos extras.
+---
+
+Use a skill **`spec-workflow`** (em `.claude/skills/spec-workflow/SKILL.md`), especificamente a **Fase 2 — Implement**.
+
+Pré-requisitos (aborta se faltar): `.specs/{feature_name}/design.md`, `impact.md`, `tasks.md`. Se faltar, pare e peça `/spec` primeiro.
+
+Regras inegociáveis:
+
+1. **Crie `journal.md`** no início. Mantenha vivo a cada desvio, erro ou pedido extra.
+2. **Uma task por vez** com checkpoint humano. Exceção: usuário disse "implemente tudo"; mesmo assim pause antes de tasks ⚠️.
+3. **3-Strike Error Protocol** — após 3 tentativas distintas pra mesma classe de erro, escale. Nunca repita ação que falhou.
+4. **2-Action Rule** — após 2 operações pesadas de leitura, escreva descobertas em `journal.md` antes que evaporem.
+5. **Atualize `tasks.md` task a task** (`- [x]`), não no final.
+6. **Pedidos extras** → registrar em `journal.md` e decidir: incorporar / sub-spec / backlog.
+7. **Final verification**: cross-task consistency + Regression Sweep (cada risco do impact.md → mitigação) + test summary. No StickerBot, o type-check real roda no build Docker (`npm run build`/`tsc`) — veja a skill `workflow-deploy`.
+8. Ao terminar, **sugira `/spec-reflect`**.
+
+$ARGUMENTS

--- a/.claude/commands/spec-reflect.md
+++ b/.claude/commands/spec-reflect.md
@@ -1,0 +1,23 @@
+---
+description: Fase 3 do spec-workflow — análise reflexiva pós-implementação. Decide se cabe criar workflow-<feature> skill, atualizar CLAUDE.md, cross-references em skills, ou aprendizados em rules.
+---
+
+Use a skill **`spec-workflow`** (em `.claude/skills/spec-workflow/SKILL.md`), especificamente a **Fase 3 — Reflect**.
+
+Pré-requisitos: `design.md`/`impact.md`/`tasks.md` existem, tasks marcadas `[x]`. Idealmente `journal.md` mantido (se não, a reflexão é mais rasa mas ainda vale).
+
+Workflow:
+
+1. **Reler `journal.md` inteiro** procurando padrões: desvios recorrentes, erros caros, pedidos que viraram parte da feature, regras descobertas.
+2. **Decision Tree (4 perguntas, uma por uma)**:
+   - P1: criar `.claude/skills/workflow-<feature>/`? (regras vivas, gotchas, contratos)
+   - P2: atualizar `CLAUDE.md`? (rota/entry-point novo, mudança macro, regra always-on nova)
+   - P3: cross-reference em skills existentes? (ex.: `workflow-database`, `workflow-commands`, `workflow-deploy`)
+   - P4: aprendizados pra `rule-project-core`/skills horizontais?
+3. **Compile `reflect.md`** com diff específico (ANTES → DEPOIS) por item.
+4. **Apresente item a item** e aplique só o aprovado.
+5. **Final report** do que foi aplicado; marque a spec como `implemented`.
+
+Importante: **não pule a Fase 3 nem em features pequenas.** A resposta pode ser "nada migra", mas a pergunta tem que ser feita — senão conhecimento evapora.
+
+$ARGUMENTS

--- a/.claude/commands/spec-retro.md
+++ b/.claude/commands/spec-retro.md
@@ -1,0 +1,33 @@
+---
+description: Análise retroativa — engenharia reversa de função/comando/feature já implementada SEM spec. Gera spec retroativa em .specs/<feature>/ e oferece dois modos: doc-only (apenas documenta) ou full (doc + Reflect que atualiza workflow skills/CLAUDE.md/rules).
+---
+
+Use a skill **`spec-workflow`** (em `.claude/skills/spec-workflow/SKILL.md`), no **Modo Retroativo** (seção dedicada na skill).
+
+## Quando usar
+
+- Existe feature/comando/função implementada **sem spec**.
+- Você quer **documentar como funciona** pra referência viva de outros devs (humanos ou agentes).
+- E/ou **consolidar o conhecimento** no `.claude/` (criar `workflow-<feature>` skill, atualizar CLAUDE.md, cross-references).
+
+## Workflow
+
+### Step 1 — Capture do alvo (Socratic Gate)
+1. Nome da feature (kebab-case).
+2. Escopo: lista de arquivos/pastas ou domínio descrito.
+3. Objetivo: **Modo A (Doc-only)** = só `.specs/<feature>/`; **Modo B (Full)** = doc + Reflect.
+
+### Step 2 — Engenharia reversa
+Crie `.specs/{feature}/` com `design.md`, `impact.md` (com Open Questions), `tasks.md` (tudo `[x]` + gaps), `journal.md` (nota retroativa + achados que viraram débito técnico). Detalhe na skill, Modo Retroativo.
+
+### Step 3 — Apresentar e decidir modo
+Mostre o spec retro e confirme. Modo A → para aqui. Modo B → segue pra Fase 3 (Reflect): Decision Tree de 4 perguntas → `reflect.md` → aplicar aprovados.
+
+## Regras críticas
+
+1. **Nunca invente comportamento.** Ambíguo → "Open Question", pergunte ao usuário.
+2. **Não modifique código durante `/spec-retro`.** Diagnóstico — só lê código e escreve markdown.
+3. **Modo B é o caminho recomendado** quando a feature é grande/importante — sem Reflect, o spec fica órfão.
+4. **Registre anti-patterns descobertos** como débito técnico no `journal.md` — input pro Reflect, não correção silenciosa.
+
+$ARGUMENTS

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,0 +1,18 @@
+---
+description: Inicia o workflow Spec-Driven Development — Fase 1 (Plan): design + impact + tasks com gates de aprovação. Use a skill spec-workflow.
+---
+
+Use a skill **`spec-workflow`** (em `.claude/skills/spec-workflow/SKILL.md`) para conduzir a feature solicitada, especificamente a **Fase 1 — Plan**.
+
+Regras inegociáveis:
+
+1. Crie o diretório `.specs/{feature_name}/` (kebab-case) na raiz do projeto.
+2. Siga os passos da Fase 1: capture intent → requirements (opcional) → design → impact → tasks.
+3. **Sempre peça aprovação explícita antes de avançar de fase** (Design Gate, Impact Gate, Tasks Gate).
+4. Antes de `tasks.md`, faça `impact.md` analisando arquivos afetados, dependências, possíveis quebras e riscos (segurança/dados/concorrência conforme `rule-project-core`).
+5. **Não implemente código.** Implementação é `/spec-implement` (Fase 2).
+6. Se houver `.specs/{feature_name}/` parcial, leia e estenda — não recomece.
+
+Socratic Gate (mín. 3 perguntas): nome da feature, problema que resolve, requirements.md ou direto pro design, spec parcial existente.
+
+$ARGUMENTS

--- a/.claude/skills/clean-code/SKILL.md
+++ b/.claude/skills/clean-code/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: clean-code
+description: Pragmatic coding standards - concise, direct, no over-engineering, no unnecessary comments. TRIGGER ao escrever ou revisar qualquer código no projeto.
+allowed-tools: Read, Write, Edit
+---
+
+# Clean Code — Pragmatic Coding Standards
+
+> Be **concise, direct, and solution-focused**.
+
+---
+
+## Core Principles
+
+| Principle | Rule |
+|-----------|------|
+| **SRP** | Single Responsibility - cada função/classe faz UMA coisa |
+| **DRY** | Don't Repeat Yourself - extraia duplicação, reutilize |
+| **KISS** | Keep It Simple - a solução mais simples que funciona |
+| **YAGNI** | You Aren't Gonna Need It - não construa o que não vai usar |
+| **Boy Scout** | Deixe o código mais limpo do que encontrou |
+
+---
+
+## Naming
+
+| Elemento | Convenção |
+|---------|------------|
+| **Variáveis** | Revelam intenção: `userCount` não `n` |
+| **Funções** | Verbo + substantivo: `getUserById()` não `user()` |
+| **Booleanos** | Forma de pergunta: `isActive`, `hasPermission`, `canEdit` |
+| **Constantes** | SCREAMING_SNAKE: `MAX_RETRY_COUNT` |
+
+> Se precisa de comentário pra explicar um nome, renomeie.
+
+---
+
+## Funções
+
+| Regra | Descrição |
+|------|-------------|
+| **Pequenas** | Idealmente 5-20 linhas |
+| **Uma coisa** | Faz uma coisa, bem feita |
+| **Um nível** | Um nível de abstração por função |
+| **Poucos args** | Máx 3, prefira 0-2 |
+| **Sem efeito colateral** | Não mutar inputs inesperadamente |
+
+Estrutura: guard clauses (early return), flat > nested (máx 2 níveis), composição de funções pequenas.
+
+---
+
+## Type discipline (TypeScript)
+
+Propagar tipos frouxos (`any`) em interfaces públicas é débito que se espalha: refactor não pega erro em compilação e o bug vaza em runtime; autocompletar morre. **Defina tipos explícitos em fronteiras públicas.** Quando inevitável (lib sem tipos), isole o `any` numa única função wrapper. (No StickerBot, `typeof tabela.$inferSelect` do Drizzle dá os tipos do banco de graça — use.)
+
+---
+
+## Anti-Patterns (NÃO)
+
+| ❌ | ✅ |
+|-----------|-------|
+| Comentar cada linha | Apague comentários óbvios |
+| Helper pra one-liner | Inline |
+| utils com 1 função | Coloque onde é usado |
+| Deep nesting | Guard clauses |
+| Magic numbers | Constantes nomeadas |
+| God functions | Divida por responsabilidade |
+| "Primeiro a gente importa..." | Só escreva o código |
+
+---
+
+## 🔴 Antes de editar QUALQUER arquivo
+
+| Pergunta | Por quê |
+|----------|-----|
+| **O que importa este arquivo?** | Pode quebrar |
+| **O que este arquivo importa?** | Mudança de interface |
+| **É componente/helper compartilhado?** | Vários lugares afetados |
+
+> Edite o arquivo + todos os dependentes na MESMA task. Nunca deixe import quebrado.
+
+---
+
+## 🔴 Self-Check antes de concluir
+
+- ✅ Fiz exatamente o que foi pedido?
+- ✅ Editei todos os arquivos necessários?
+- ✅ Verifiquei que funciona (não só compila)?
+- ✅ Lint/type-check limpo?
+
+> O usuário quer código funcionando, não uma aula de programação.

--- a/.claude/skills/quality-assurance/SKILL.md
+++ b/.claude/skills/quality-assurance/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: quality-assurance
+description: Checklists de entrega — verificações antes de fechar feature/PR/commit: type-check (npm run build no Docker), comportamento verificado (não só compila), leis do projeto respeitadas (migração via ensureColumn, permissão grupo vs bot, concorrência fire-and-forget, backup antes de destrutivo). TRIGGER antes de commit/PR de feature, ao finalizar implementação, na verification phase do spec-implement, ou quando o usuário pede "está pronto?" / "revisa antes de mergear".
+---
+
+# Quality Assurance — QA & verificação de entrega (StickerBot)
+
+## 📝 Pré-implementação
+
+- [ ] Entendi exatamente o que foi pedido (sem suposição)?
+- [ ] Verifiquei `rule-project-core` + a `workflow-*` da área (`workflow-database`/`workflow-commands`/`workflow-deploy`)?
+- [ ] Sei quais arquivos/dependências a mudança vai tocar?
+
+## 🛠️ Verificação final (antes de "pronto")
+
+- **Type-check**: `npm run build` (tsc) passa? No StickerBot o confiável é **dentro do build Docker** (não há tsc local garantido). Build que falha lá não derruba o container atual.
+- **Comportamento real**: a feature *funciona* (rodei/testei o caminho feliz + edge), não só compila?
+- **Logs limpos**: sem erro novo nos `docker compose logs`; `[COMMANDS] N loaded` e `ready` aparecem no boot.
+- **Sem regressão**: o que mudei não quebrou o fluxo de criar figurinha nem os comandos vizinhos.
+
+## 🛡️ Leis transversais (StickerBot)
+
+- **Banco/migração:** mexeu em schema? Atualizei `schema.ts` **+** `CREATE TABLE` em `db.ts` **+** `ensureColumn` se a tabela já existe em prod? O log `[DB] Migration: ...` confirmou no deploy?
+- **Permissão:** comando admin gateado no nível certo — **admin do grupo** (`isGroupAdmin`) vs **operador do bot** (`isBotAdmin`)?
+- **Concorrência:** handler fire-and-forget reserva o estado em memória de forma **síncrona antes do `await`**? Tem `try/catch` interno (não vaza exceção)?
+- **Destrutivo em prod:** `DROP`/delete em massa tem **dump de backup antes**? Se dropei tabela do `initializeDB`, o código já parou de recriá-la?
+- **Config:** hot path lê o cache em memória (não o banco a cada chamada)?
+
+## 🧹 Higiene final
+
+- [ ] Sem código morto, sem `console.log`/TODO órfão?
+- [ ] Sem scripts temporários soltos na raiz (o `COPY . .` do Docker os arrastaria pro build)?
+- [ ] Diff revisado — só o que era pra mudar mudou? Sem segredo commitado (repo público)?

--- a/.claude/skills/rule-project-core/SKILL.md
+++ b/.claude/skills/rule-project-core/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: rule-project-core
+description: "StickerBot — leis always-on do sistema. TRIGGER ao mexer com: banco de dados / schema / migração (Drizzle + MySQL, sem framework de migração → ensureColumn), criar ou editar comando (auto-loader em src/handlers/text.ts, permissões admin-do-grupo vs admin-do-bot), handlers fire-and-forget / estado em memória / concorrência, config em runtime (Settings + cache), envio de mensagem/menção/mídia via Baileys, ou ao fazer operação destrutiva no banco em produção. Estas leis são a autoridade máxima sobre restrições do sistema."
+---
+
+# Rule: PROJECT_CORE — Leis fundamentais do StickerBot (always-on)
+
+> StickerBot = bot de WhatsApp (Baileys v7 + TypeScript, Node 20) que cria figurinhas e tem monetização (VIP via MercadoPago PIX, anúncios). Persistência: **Drizzle ORM + MySQL** (`mysql2`). Webserver Express. Roda em Docker. Estas leis são inegociáveis.
+
+---
+
+## 🗄️ 1. Banco de dados & migrações
+
+- **Drizzle ORM sobre MySQL (`mysql2`)**. Schema tipado em `src/db/schema.ts` (fonte da verdade — tipos via `typeof tabela.$inferSelect`). Acesso via `db` / `pool` exportados de `src/handlers/db.ts`.
+- **NÃO existe framework de migração.** `initializeDB()` (em `src/handlers/db.ts`) só roda `CREATE TABLE IF NOT EXISTS` no boot. Isso **não altera tabela que já existe** em produção.
+- **Adicionar coluna a tabela existente → migração idempotente obrigatória:** use o helper `ensureColumn(table, column, definition)` (checa `information_schema.COLUMNS` e só faz `ALTER TABLE ... ADD COLUMN` se faltar — funciona em MySQL **e** MariaDB, que é o motivo de não usar `ADD COLUMN IF NOT EXISTS`). Roda no boot, é seguro/instantâneo em tabela vazia ou pequena, e loga `[DB] Migration: added column X to Y`.
+- Ao adicionar/alterar tabela ou coluna: **atualize `schema.ts` (Drizzle) E o `CREATE TABLE` em `db.ts`**, e adicione o `ensureColumn` se a tabela já existir em prod.
+- **Upsert** = `db.insert(...).values(...).onDuplicateKeyUpdate({ set: {...} })`. Incremento atômico = `sql\`${col} + 1\``.
+- Reserved words (ex.: coluna `key`) são quotadas pelo Drizzle automaticamente; em SQL cru, use crase.
+
+## 🧩 2. Comandos & permissões
+
+- Comandos ficam em `src/commands/*.ts`, cada um exportando `command: StickerBotCommand`. O **auto-loader** (`src/handlers/text.ts`) carrega todos automaticamente — não há registro manual. (Detalhe completo: skill `workflow-commands`.)
+- **Sempre** chame `checkCommand(...)` no início do `run` e `return` se falhar.
+- **Permissão (não confundir):**
+  - `onlyAdmin: true` → exige **admin do GRUPO** (`isGroupAdmin`).
+  - `onlyBotAdmin: true` → exige **operador do bot** (`isBotAdmin`, lista `SB_ADMINS`).
+  - Features de comunidade/multi-grupo (ex.: lista de pelada) gateiam ações de gestão no **admin do grupo**, não no admin do bot.
+  - Comando com subcomandos mistos (parte pública, parte admin): deixe o comando aberto (`onlyAdmin: false`) e gateie cada subcomando admin por dentro com `if (!isGroupAdmin) { reply; return }`.
+
+## ⚙️ 3. Concorrência & fire-and-forget
+
+- Vários handlers são disparados em **fire-and-forget** (ex.: `void maybeSendAd(...)` após cada figurinha). Em **rajadas** (usuário manda 10 figurinhas), eles rodam concorrentes.
+- **Check-then-act sobre estado em memória compartilhado** (contadores, flags) DEVE reservar/commitar de forma **síncrona, ANTES do primeiro `await`** (flag de in-flight + reset) — senão cada chamada concorrente cruza o limite e o efeito duplica. (Bug real: anúncio enviado em dobro numa rajada.)
+- Em fire-and-forget, **nunca deixe exceção vazar** — `try/catch` interno; uma falha aqui não pode quebrar o fluxo principal (criação da figurinha).
+
+## 💾 4. Integridade de dados & operações destrutivas
+
+- O projeto usa **hard delete** (`db.delete(...)`) — não há soft-delete. Não invente `deletedAt`.
+- **Operação destrutiva em produção (DROP, TRUNCATE, delete em massa) exige backup ANTES:** dump (`mysqldump`) das tabelas afetadas e/ou cópia dos arquivos de código tocados. Veja a skill `workflow-deploy` para o procedimento.
+- Datas: o projeto usa `new Date()` direto (sem helper central). Atenção ao round-trip de `DATETIME` no mysql2 (depende do TZ do processo; o container roda em BRT/-03:00). Exibição em pt-BR via `toLocaleString('pt-BR', { ... })`.
+
+## 🔧 5. Config & config em runtime
+
+- Toda config vem do objeto `bot` em `src/config.ts` (env-driven, com defaults). As envs de produção ficam **inline no `docker-compose.yml`** (não há `.env` em prod).
+- **Padrão de config editável em runtime** (sem redeploy): tabela genérica `Settings` (key/value) + cache em memória carregado no boot (`loadXConfig()` chamado em `bot.ts` após `initializeDB()`) + setters que gravam no banco E atualizam o cache. A ENV vira **seed/fallback**. Hot paths leem o cache, **nunca** o banco.
+
+## 📨 6. WhatsApp / Baileys
+
+- Reaproveite os helpers de `src/utils/baileysHelper.ts` (`sendMessage`, `react`, `getQuotedMessage`, `getPhoneFromJid`, `getMessageAuthor`, etc.) — **não reinvente**.
+- Nome de exibição do remetente = `message.pushName`.
+- **Menção**: monte `mentions: [jid, jidEncode(phone, 's.whatsapp.net')]` (com `phone = await getPhoneFromJid(jid)`) e cite `@${phone}` no texto. Padrão em `commands/raffle.ts`.
+- Mensagem citada: `message.message?.extendedTextMessage?.contextInfo?.quotedMessage` — **trate o wrapper `ephemeralMessage`** (o bot pode ter modo desaparecer ligado via `SB_DEFAULT_DISAPPEARING_MODE`).
+- `spintax('{a|b}')` (em `utils/misc`) para variar texto e parecer menos robótico.
+
+## ⚠️ 7. Estilo de código & verificação
+
+- **Sem ponto-e-vírgula**, aspas simples, indent 2 espaços, `object-property-newline` (uma propriedade por linha em objeto multilinha), `max-len` 124. Vírgula final nos objetos de `schema.ts`, **mas não** nos objetos de query (`.values()` / `.set()`). Config em `.eslintrc`.
+- **Não há `node_modules`/`tsc`/eslint garantidos localmente.** O type-check confiável é o `npm run build` (= `tsc`) **dentro do build Docker**. Um `tsc` que falha lá faz o build falhar e **deixa o container atual no ar** (seguro). Erros de tipo do `wa-sticker-formatter` que aparecem localmente são artefato de dep github não instalada — compilam no Docker.
+- Logger central: `getLogger()` (pino). Use `logger.info/error`.
+- **Higiene:** analise o código existente antes de codar; mantenha a raiz limpa (sem scripts temporários soltos — eles entram no contexto do build Docker via `COPY . .`).
+
+---
+
+> Mantenha esta `description` sincronizada com as seções acima — é o que faz a skill carregar na hora certa. Detalhes profundos: `workflow-database`, `workflow-commands`, `workflow-deploy`.

--- a/.claude/skills/safe-refactoring/SKILL.md
+++ b/.claude/skills/safe-refactoring/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: safe-refactoring
+description: Estratégias de refatoração segura — quebrar arquivos grandes, extrair função/handler quando um bloco fica grande demais, Dispatcher Pattern para orquestradores grandes, refator incremental (slice, não big-bang), preservar API pública estável, 1 commit = 1 transformação reversível, NUNCA misturar refator + feature no mesmo commit. TRIGGER quando um arquivo/função cresce demais, ou quando o usuário pede "refatora", "extrai", "limpa esse arquivo", "quebra esse monolito", ou ao revisar PR pra detectar code smell de tamanho.
+---
+
+# Safe Refactoring — Quebrando monólitos com segurança
+
+## 🛠️ Protocolo "Extract-First"
+
+- **Extração imediata**: se um bloco (função, switch grande, handler) tem responsabilidade clara separável, extraia pra unidade própria.
+- **Lógica isolada**: tire efeitos colaterais / chamadas async / setup pesado pra helpers/handlers dedicados, deixando o orquestrador leve.
+- **Early guards**: valide nulidade/tipos no topo das unidades extraídas.
+
+## 🔄 Padrão Dispatcher
+
+Quando um arquivo centraliza muitos casos (muitos comandos, muitos subcomandos), use um **Dispatcher**: o orquestrador decide *qual* unidade chamar (via `switch`/mapa) e delega. No StickerBot, `handlers/text.ts` já é um dispatcher de comandos (auto-loader por alias); comandos com muitos subcomandos (ex.: `lista.ts`) podem extrair os handlers de cada subcomando.
+
+## 🐢 Incremental, nunca big-bang
+
+- Extraia **uma** sub-unidade por vez, valide (compila + comportamento), e só então a próxima.
+- **1 commit = 1 transformação reversível.** Nunca misture refator estrutural com mudança de comportamento no mesmo commit — se quebrar, impossível bissectar.
+- **Preserve a API pública**: se outros módulos importam o que você move, mantenha um re-export estável durante a transição. (No StickerBot, ao mexer em `db.ts`, preserve a assinatura dos helpers exportados — eles são consumidos em comandos/handlers.)
+
+## 🛡️ Verificação de integridade
+
+- **Type-check** após cada extração (`npm run build`/tsc — no StickerBot o confiável é no build Docker, ver `workflow-deploy`).
+- Confirme que funções "órfãs" não foram removidas por engano; cheque imports quebrados.
+- Se a mudança não reflete no runtime, suspeite de cache/hot-reload preso — reinicie o processo/container antes de concluir que o refator falhou.

--- a/.claude/skills/spec-workflow/SKILL.md
+++ b/.claude/skills/spec-workflow/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: spec-workflow
+description: Spec-Driven Development unificado em 3 fases + Modo Retroativo. Plan (design.md + impact.md + tasks.md em .specs/<feature>/ com gates de aprovação), Implement (executa tasks uma a uma com checkpoint + post-task verification + 3-Strike Error Protocol, mantém journal.md vivo registrando desvios, erros+soluções e pedidos extras), Reflect (análise pós-implementação visitando journal.md, propondo criar workflow-<feature> skill, atualizar CLAUDE.md, cross-references e aprendizados em rules). Modo Retroativo faz engenharia reversa de feature já implementada SEM spec. TRIGGER ao iniciar feature nova, planejar implementação complexa multi-arquivo, executar spec já planejado em .specs/, capturar desvios durante implementação, ou consolidar/documentar conhecimento de um módulo.
+---
+
+# Spec Workflow — Plan → Implement → Reflect (+ Retro)
+
+> Use sempre que for implementar feature que envolva mais de 1-2 arquivos, mude schema, ou tenha risco de regressão — e pra documentar módulos existentes (Modo Retroativo).
+
+## Princípios
+
+1. **Filesystem é memória persistente.** Decisões, descobertas, erros e desvios vão pra arquivo. Context window é volátil.
+2. **Gates de aprovação são inegociáveis.** Cada fase tem checkpoint humano. Não avance sem confirmação explícita.
+3. **Plano vivo.** O spec não é fotografia — `journal.md` captura o delta entre plano e realidade.
+4. **Reflexão fecha o ciclo.** Conhecimento adquirido vira skill/rule/CLAUDE.md update — senão evapora.
+
+## Estrutura de artefatos
+
+Toda feature mora em `.specs/<feature_name>/` (kebab-case):
+
+| Arquivo | Fase | Obrigatório | Propósito |
+|---|---|---|---|
+| `requirements.md` | 1 | ❌ | User stories (use quando escopo é ambíguo ou stakeholder não-técnico) |
+| `design.md` | 1 | ✅ | Arquitetura, modelos, contratos, snippets do core |
+| `impact.md` | 1 | ✅ | Change surface, regression risk, integração segura |
+| `tasks.md` | 1 | ✅ | Checklist numerado com risk levels (⚠️ = alto risco) |
+| `journal.md` | 2 | ✅ ao iniciar Fase 2 | Diário vivo: desvios, erros+soluções, pedidos extras |
+| `reflect.md` | 3 | ✅ | Decisões da reflexão + diff proposto pro `.claude/` |
+
+---
+
+## FASE 1 — Plan
+
+### 1.1 Capture Intent (Socratic Gate)
+
+Antes de criar arquivo:
+1. Qual o nome da feature? (kebab-case)
+2. Qual o problema que resolve? (1-2 frases — não a solução)
+3. Há `.specs/<feature>/` parcial? Se sim → ler e estender, não recomeçar.
+4. Quer começar com `requirements.md`? (escopo ambíguo / stakeholder não-técnico).
+
+Crie `.specs/<feature_name>/`.
+
+### 1.2 design.md
+Arquitetura proposta, modelos/entidades tocados, contratos (comandos/handlers/tipos), snippets do core (não tudo). Mapeie concerns do `rule-project-core` que se aplicam (DB/migração, permissão, concorrência fire-and-forget, deploy).
+
+### 1.3 impact.md
+Arquivos afetados, dependências, possíveis quebras, riscos (dados/concorrência/permissão conforme o projeto). **Gate**: aprovação antes de tasks.
+
+### 1.4 tasks.md
+Checklist numerado, granular, com ⚠️ nas de alto risco (mudança de schema, DROP, deploy em produção). **Gate**: aprovação antes de implementar.
+
+> Não implemente código na Fase 1. Implementação é a Fase 2 (`/spec-implement`).
+
+---
+
+## FASE 2 — Implement
+
+Pré-requisitos: `design.md` + `impact.md` + `tasks.md` existem. Se faltar, pare e peça `/spec` primeiro.
+
+1. **Crie `journal.md`** no início. Mantenha vivo a cada desvio/erro/pedido extra.
+2. **Uma task por vez** com checkpoint humano. Exceção: usuário disse "implemente tudo"; mesmo assim pause antes de tasks ⚠️.
+3. **3-Strike Error Protocol**: após 3 tentativas distintas pra mesma classe de erro, escale pro usuário. Nunca repita ação que falhou.
+4. **2-Action Rule**: após 2 operações pesadas de leitura/pesquisa, escreva descobertas em `journal.md` antes que evaporem do contexto.
+5. **Atualize `tasks.md` task a task** (`- [x]`), não no final.
+6. **Pedidos extras** do usuário → registrar em `journal.md` e decidir: incorporar / sub-spec / backlog.
+7. **Final verification**: cross-task consistency + Regression Sweep (cada risco do impact.md → mitigação) + test summary. No StickerBot o type-check confiável é o `npm run build` (tsc) dentro do build Docker — não há `node_modules`/`tsc` local garantido (ver `workflow-deploy`).
+8. Ao terminar, **sugira `/spec-reflect`**.
+
+---
+
+## FASE 3 — Reflect
+
+Pré-requisitos: tasks concluídas. Idealmente `journal.md` mantido.
+
+1. **Reler `journal.md`** procurando padrões: desvios recorrentes, erros caros, pedidos que viraram parte da feature, regras descobertas.
+2. **Decision Tree (4 perguntas, uma por uma)**:
+   - **P1**: criar `.claude/skills/workflow-<feature>/`? Sim se há regras vivas, gotchas, contratos que outros precisam saber.
+   - **P2**: atualizar `CLAUDE.md`? Sim se comando/entry-point novo, mudança arquitetural macro, ou regra always-on nova.
+   - **P3**: cross-reference em skills existentes? Pra cada skill que toca a área (`workflow-database`, `workflow-commands`, `workflow-deploy`), um dev lendo descobriria a feature?
+   - **P4**: aprendizados pra `rule-project-core`/horizontais? (ex: bug recorrente de concorrência → reforçar a lei).
+3. **Compile `reflect.md`** com diff específico (ANTES → DEPOIS) por item.
+4. **Apresente item a item** e aplique só o aprovado.
+5. **Final report** do que foi aplicado.
+
+> Não pule a Fase 3 nem em features pequenas. A resposta pode ser "nada migra", mas a pergunta tem que ser feita.
+
+---
+
+## MODO RETROATIVO — engenharia reversa (usado pelo /spec-retro)
+
+Pra documentar feature/módulo **já implementado SEM spec**.
+
+### R.1 Capture do alvo
+1. Nome da feature (kebab-case).
+2. Escopo: lista de arquivos/pastas ou domínio descrito.
+3. Objetivo: **Modo A (Doc-only)** = só gerar `.specs/<feature>/`; **Modo B (Full)** = doc + Reflect.
+
+### R.2 Engenharia reversa (Reverse Plan)
+Crie `.specs/<feature>/` a partir do código existente:
+- **`design.md`**: overview (inferido), componentes/responsabilidades, data models/contratos, snippets do core, testing strategy (ou ausência).
+- **`impact.md`**: codebase mapping (arquivos que formam a feature), dependências, risco implícito (acoplamentos, falta de validação/testes), **Open Questions** (o que ficou ambíguo).
+- **`tasks.md`**: checklist retroativa, tudo `[x]`; ao final, seção "Tasks que deveriam existir e não foram feitas" (gaps: falta teste, audit, etc.).
+- **`journal.md`**: nota de que foi gerado retroativamente; "Achados que viraram débito técnico" (anti-patterns descobertos).
+
+### R.3 Apresentar e decidir modo
+Mostre o spec retro, confirme correção. Modo A → para aqui. Modo B → segue pra Fase 3 (Reflect).
+
+### Regras críticas do Modo Retroativo
+1. **Nunca invente comportamento.** Ambíguo → "Open Question", não suposição.
+2. **Não modifique código.** Diagnóstico apenas — só lê código e escreve markdown.
+3. **Registre débito técnico** descoberto no `journal.md` (vira input pro Reflect, não correção silenciosa).

--- a/.claude/skills/workflow-commands/SKILL.md
+++ b/.claude/skills/workflow-commands/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: workflow-commands
+description: Como criar e editar comandos do StickerBot. TRIGGER ao adicionar um comando novo em src/commands/, editar um comando existente, mexer com permissões (admin do grupo vs admin do bot), parsing de argumentos, respostas/reações, menções ou subcomandos. Cobre o auto-loader, a interface StickerBotCommand, checkCommand, os helpers de baileysHelper e os padrões de permissão.
+---
+
+# Workflow: Comandos do StickerBot
+
+## Auto-loader (não há registro manual)
+
+Cada arquivo em `src/commands/*.ts` exporta `command: StickerBotCommand`. O dispatcher `src/handlers/text.ts` carrega **todos** automaticamente no boot e roteia por alias. Para adicionar um comando, **basta criar o arquivo** — nada de registrar.
+
+- Nome do arquivo = alias principal (`ping.ts`, `ads.ts`, `lista.ts`).
+- Tipos em `src/types/Command.ts` (`StickerBotCommand`, assinatura do `run`) e `src/types/Message.ts` (`WAMessageExtended`).
+
+## Esqueleto
+
+```ts
+import { GroupMetadata } from '@whiskeysockets/baileys'
+import path from 'path'
+
+import { StickerBotCommand } from '../types/Command'
+import { WAMessageExtended } from '../types/Message'
+import { react, sendMessage } from '../utils/baileysHelper'
+import { checkCommand } from '../utils/commandValidator'
+import { emojis } from '../utils/emojis'
+import { getLogger } from '../handlers/logger'
+import { capitalize, getRandomItemFromArray } from '../utils/misc'
+
+const logger = getLogger()
+const extension = __filename.endsWith('.js') ? '.js' : '.ts'
+const commandName = capitalize(path.basename(__filename, extension))
+
+export const command: StickerBotCommand = {
+  name: commandName,
+  aliases: ['meucomando', 'alias2'],
+  desc: 'O que o comando faz.',
+  example: 'meucomando <param>',
+  needsPrefix: true,        // exige prefixo (! / @ # .)
+  inMaintenance: false,
+  runInPrivate: true,
+  runInGroups: true,
+  onlyInBotGroup: false,
+  onlyBotAdmin: false,      // operador do bot (SB_ADMINS)
+  onlyAdmin: false,         // admin do GRUPO
+  onlyVip: false,
+  botMustBeAdmin: false,    // o bot precisa ser admin do grupo?
+  interval: 5,              // cooldown (s)
+  limiter: {},              // não mexer
+  run: async (
+    jid, sender, message: WAMessageExtended, alias, body,
+    group: GroupMetadata | undefined,
+    isBotAdmin, isVip, isGroupAdmin, amAdmin
+  ) => {
+    const check = await checkCommand(jid, message, alias, group, isBotAdmin, isVip, isGroupAdmin, amAdmin, command)
+    if (!check) return
+
+    try {
+      // argumentos = tudo depois do prefixo + alias
+      const params = body.slice(command.needsPrefix ? 1 : 0).replace(new RegExp(`^${alias}\\s*`, 'i'), '').trim()
+      return await sendMessage({ text: 'ok!' }, message)
+    } catch (error) {
+      logger.error(`Error in ${commandName}: ${error}`)
+      return await react(message, emojis.error)
+    }
+  }
+}
+```
+
+**Sempre** rode `checkCommand(...)` primeiro e `return` se falhar (ele valida prefixo, escopo, permissão, cooldown, manutenção).
+
+## Permissões (não confundir — lei do projeto)
+
+- `onlyAdmin: true` → exige **admin do GRUPO** (`isGroupAdmin`).
+- `onlyBotAdmin: true` → exige **operador do bot** (`isBotAdmin`).
+- Features multi-grupo (comunidade) → gateie a gestão no **admin do grupo**, não no admin do bot.
+- **Comando com subcomandos mistos** (parte pública, parte admin): deixe `onlyAdmin: false` e gateie cada subcomando admin por dentro:
+  ```ts
+  const requireAdmin = async () => {
+    if (!isGroupAdmin) { await sendMessage({ text: '⚠ Só admins do grupo.' }, message); return false }
+    return true
+  }
+  // ...
+  if (sub === 'criar') { if (!await requireAdmin()) return; /* ... */ }
+  ```
+
+## Parsing de subcomandos
+
+```ts
+const parsed = params.match(/^(\S+)\s*([\s\S]*)$/)
+const sub = (parsed?.[1] || '').toLowerCase()
+const argText = (parsed?.[2] || '').trim()   // preserva quebras de linha (útil pra conteúdo multilinha)
+```
+Convenção útil: **com nome no argumento = age sobre aquela pessoa/valor; sem argumento = age sobre o remetente** (ver `lista.ts`).
+
+## Helpers (reaproveitar — não reinventar) — `src/utils/baileysHelper.ts`
+
+- `sendMessage(content, message)` — responde (texto/imagem/etc.), citando a mensagem.
+- `react(message, emoji)` — reage. `emojis.success` é array (`getRandomItemFromArray`), `emojis.error` é string.
+- `getQuotedMessage(message)` / contextInfo — mensagem citada (**trate `ephemeralMessage`**, pois o bot pode ter modo desaparecer ligado).
+- `getPhoneFromJid(jid)` (async) — telefone correto (evita bug de LID/DDI do Baileys v7).
+- **Menção**: `mentions: [jid, jidEncode(phone, 's.whatsapp.net')]` + `@${phone}` no texto (padrão em `raffle.ts`).
+- Nome do remetente: `message.pushName`.
+- `compareJids`, `isJidAdminOfGroup`, `amAdminOfGroup` — comparação/checagem robusta de jids.
+
+## Verificação
+
+- Type-check confiável = `npm run build` (tsc) no **build Docker** (não há `tsc`/`node_modules` local garantido — ver `workflow-deploy`). Localmente `npx tsc --noEmit` funciona se as deps estiverem instaladas.
+- O comando aparece no boot: `[COMMANDS] N commands have been loaded!` (N deve subir em 1).
+
+> Há uma skill legada `.agents/skills/create_command/SKILL.md` com a mesma ideia — esta `workflow-commands` a substitui (mais completa). Pode remover a antiga.

--- a/.claude/skills/workflow-database/SKILL.md
+++ b/.claude/skills/workflow-database/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: workflow-database
+description: Camada de persistência do StickerBot — Drizzle ORM sobre MySQL (mysql2). TRIGGER ao adicionar/alterar tabela ou coluna, escrever query, mexer em src/db/schema.ts ou src/handlers/db.ts, criar migração, ou padrão de config em runtime (Settings + cache). Cobre: schema tipado, CREATE TABLE IF NOT EXISTS no boot, migração idempotente via ensureColumn (sem framework de migração), padrões de query/upsert, e o script SQLite→MySQL.
+---
+
+# Workflow: Banco de Dados (Drizzle + MySQL)
+
+## Onde vive
+
+- **`src/db/schema.ts`** — schema Drizzle (`mysqlTable`). **Fonte da verdade dos tipos** (`type Row = typeof tabela.$inferSelect`).
+- **`src/handlers/db.ts`** — `initializeDB()` (cria pool mysql2 + `db = drizzle(pool)` + `CREATE TABLE IF NOT EXISTS` de cada tabela + migrações `ensureColumn`), e os helpers de acesso (`getCount`, `getVips`, `ban`, `getSetting`/`setSetting`, etc.). Exporta `pool` e `db`.
+- Config de conexão vem de `bot.dbHost/dbUser/dbPassword/dbName/dbPort` (`config.ts`, env-driven). `drizzle.config.ts` aponta pro schema (para `drizzle-kit`).
+
+## ⚠️ NÃO há framework de migração
+
+`initializeDB` só roda `CREATE TABLE IF NOT EXISTS`. Isso **cria** tabela nova, mas **não altera** tabela que já existe em produção. Logo:
+
+### Adicionar uma TABELA nova
+1. Definir em `schema.ts` (`export const x = mysqlTable('X', { ... })`).
+2. Adicionar `CREATE TABLE IF NOT EXISTS \`X\` (...)` em `initializeDB`.
+3. Pronto — o boot cria. (Importe a tabela em `db.ts` só se for usar o objeto Drizzle lá.)
+
+### Adicionar uma COLUNA a tabela existente (migração idempotente obrigatória)
+1. Adicionar a coluna em `schema.ts`.
+2. Adicionar a coluna no `CREATE TABLE` (para instalações novas).
+3. **Adicionar a migração** no fim de `initializeDB`:
+   ```ts
+   await ensureColumn('Tabela', 'coluna', 'TINYINT(1) NOT NULL DEFAULT 0')
+   ```
+   `ensureColumn(table, column, definition)` checa `information_schema.COLUMNS` e só faz `ALTER TABLE ... ADD COLUMN` se faltar — **funciona em MySQL e MariaDB** (por isso não usa `ADD COLUMN IF NOT EXISTS`, que é só MariaDB). É idempotente, seguro/instantâneo em tabela pequena, e loga `[DB] Migration: added column X to Y`.
+
+> Verifique em produção que a migração rodou: o log de boot mostra a linha `[DB] Migration: ...` na primeira subida; `DESCRIBE <Tabela>` confirma a coluna. (Como rodar SQL/Node dentro do container: skill `workflow-deploy`.)
+
+## Padrões de query
+
+```ts
+// select
+const rows = await db.select().from(ads).where(eq(ads.active, 1)).limit(1)
+// aleatório
+.orderBy(sql`RAND()`)
+// insert
+await db.insert(ads).values({ content, createdAt: new Date(), updatedAt: new Date() })
+// upsert
+await db.insert(settings).values({ key, value }).onDuplicateKeyUpdate({ set: { value } })
+// incremento atômico
+await db.update(ads).set({ sentCount: sql`${ads.sentCount} + 1` }).where(eq(ads.id, id))
+// delete (HARD delete — não há soft-delete no projeto)
+await db.delete(ads).where(eq(ads.id, id))
+```
+
+- Imports drizzle: `eq, and, or, asc, desc, sql` de `'drizzle-orm'`.
+- **Reserved words** (ex.: coluna `key`): o Drizzle quota com crase automaticamente; em SQL cru use crase manualmente.
+- Para `insertId` ou pegar a linha recém-criada de forma portável, reconsulte (ex.: `getActiveList`) em vez de depender de `insertId`.
+
+## Estilo nos objetos de query
+
+`object-property-newline` vale, **mas** os objetos de `.values()`/`.set()` **não** levam vírgula final (≠ objetos de `schema.ts`, que levam). Sem `;`, aspas simples.
+
+## Migração de dados (one-off)
+
+`src/scripts/migrate-db.ts` (`npm run migrate-db`) migra o SQLite legado → MySQL (Usage/Vips/Banned). `drizzle-kit push` via `npm run db:push`. São ferramentas de dev; `sqlite`/`sqlite3` ficam em `devDependencies`.
+
+## Config em runtime (padrão Settings)
+
+Para tornar algo configurável sem redeploy: tabela `Settings` (key/value) + cache em memória + `loadXConfig()` no boot (chamado em `bot.ts` após `initializeDB()`) + setters que gravam no banco E atualizam o cache. ENV = seed/fallback. **Hot paths leem o cache, nunca o banco.**

--- a/.claude/skills/workflow-deploy/SKILL.md
+++ b/.claude/skills/workflow-deploy/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: workflow-deploy
+description: Como buildar e fazer deploy do StickerBot em produção (Docker Compose) a partir de uma máquina Windows via PuTTY plink/pscp. TRIGGER ao fazer deploy, buildar a imagem, mexer no docker-compose.yml, rodar comandos no servidor de produção, fazer migração/backup de banco em prod, ou rodar um script Node dentro do container. Cobre o procedimento seguro de deploy, as armadilhas de quoting do PowerShell→plink e backups antes de operações destrutivas.
+---
+
+# Workflow: Build & Deploy (produção)
+
+> **Nunca** coloque segredos (senha root, senha do banco, tokens) em arquivo commitado — este repo é público. Credenciais são fornecidas pelo operador na hora.
+
+## Topologia de produção
+
+- Roda em **Docker Compose** no servidor (`root@<PROD_HOST>`, projeto em `/root/stickerbot`). O serviço `stickerbot` usa `build: .` → Dockerfile faz `npm install` → `npm run build` (tsc) → `node dist/bot.js`.
+- **As envs de produção ficam inline no `docker-compose.yml`** (bloco `environment:`), **não** há `.env` em prod. Quando pedirem "ajusta o .env", é o bloco do compose.
+- Volume **`/data:/data`** guarda as credenciais da sessão WhatsApp → **recriar o container NÃO pede QR de novo**.
+- O banco MySQL fica no mesmo host (acessível por `mysql`/`mysqldump` no servidor).
+
+## Ferramentas no Windows (PowerShell + PuTTY)
+
+Use **plink/pscp** via PowerShell (não há `sshpass`/`rsync`; OpenSSH não aceita senha por CLI):
+```powershell
+plink -batch -ssh -pw <senha> root@<PROD_HOST> "comando remoto"
+pscp  -batch -pw <senha> "local\arquivo" root@<PROD_HOST>:/root/stickerbot/caminho
+```
+
+**Armadilhas de quoting (importantes):**
+- **Não** use `cmd /c "plink ... \"...\""` — o aninhamento de aspas corrompe o comando (`root@` vira `oot@`).
+- O parser do **PowerShell quebra** quando o comando remoto tem **aspas duplas, parênteses ou `*`** (ex.: `grep "(...)"`, `node -e` com `COUNT(*)`). Use **só aspas simples** nos padrões internos (grep/sed), e escape `$` remoto como `` `$ `` (ex.: `sed -i 's/\r`$//'`).
+- Para qualquer coisa com aspas duplas/parênteses/`*` embutidos (awk, `node -e`, SQL com `COUNT(*)`), **escreva um arquivo `.sh`/`.js` local, `pscp` ele (transfere literal, sem mangling), normalize CRLF→LF (`sed -i 's/\r$//' script`) e rode.**
+
+## Procedimento seguro de deploy
+
+1. **Backup** dos arquivos a sobrescrever no servidor (ex.: `cp` pra `/root/stickerbot_backup_<ts>/`). Para mudança de banco, `mysqldump` das tabelas afetadas.
+2. **`pscp`** só os arquivos alterados pros caminhos correspondentes em `/root/stickerbot/...`.
+3. **Normalizar LF**: `for f in ...; do sed -i 's/\r$//' $f; done` (arquivos vindos do Windows podem ter CRLF).
+4. **Validar compose** (se mexeu nele): `docker compose config -q`.
+5. **Buildar**: `docker compose build stickerbot`. O `tsc` roda aqui — **se falhar, o build falha e o container atual continua no ar** (seguro). Erros de tipo de `wa-sticker-formatter` são artefato local; compilam no Docker.
+6. **Subir**: `docker compose up -d stickerbot` (recria só esse serviço; `/data` preservado → sem QR novo).
+7. **Verificar**: `docker compose ps stickerbot`, `docker inspect stickerbot --format '{{.RestartCount}}'` (espera 0), e `docker compose logs --tail=60 stickerbot` (procure `[COMMANDS] N loaded`, `ready`, e ausência de erros).
+
+## Rodar um Node one-off dentro do container
+
+`mysql2` e o `node_modules` vivem em `/usr/src/app` no container:
+```powershell
+pscp -batch -pw <senha> check.js root@<PROD_HOST>:/root/stickerbot/check.js
+plink -batch -ssh -pw <senha> root@<PROD_HOST> "cd /root/stickerbot && docker compose cp check.js stickerbot:/usr/src/app/check.js && docker compose exec -T -w /usr/src/app stickerbot node check.js"
+```
+Use `-w /usr/src/app` (senão o Node não acha `mysql2`). Limpe os scripts auxiliares de `/root/stickerbot` depois — o `COPY . .` do build os arrastaria pra imagem.
+
+## Banco em produção (destrutivo)
+
+- **Antes de `DROP`/delete em massa: faça dump.** `mysqldump -h <host> -u <user> -p'<senha>' --no-tablespaces <db> Tabela1 Tabela2 > /root/dump_<ts>.sql`.
+- Se for **dropar** tabelas que o `initializeDB` recria: primeiro faça **deploy do código** que removeu o `CREATE TABLE` (e o `ensureColumn`), depois dropе — senão o próximo boot recria as tabelas vazias.
+- Verifique com um script Node (padrão acima) ou `mysql -e 'SHOW TABLES'`.
+
+## Migração de schema no deploy
+
+Mudou `schema.ts`/`db.ts` com coluna nova? O `ensureColumn` roda no boot e migra a tabela existente automaticamente — confirme no log `[DB] Migration: added column ... ` após o `up -d` (ver `workflow-database`).

--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,6 @@ dist
 
 # Docker
 docker-compose.yml
+
+# Claude Code — local settings/permissions (machine-specific, not shared)
+.claude/settings.local.json

--- a/.specs/README.md
+++ b/.specs/README.md
@@ -1,0 +1,23 @@
+# .specs/ — Specs ativos (Spec-Driven Development)
+
+Cada feature mora em `.specs/<feature-name>/` (kebab-case) e é gerenciada pela skill
+[`spec-workflow`](../.claude/skills/spec-workflow/SKILL.md) via os comandos `/spec*`.
+
+| Arquivo | Fase | Propósito |
+|---|---|---|
+| `requirements.md` | Plan | User stories (opcional, escopo ambíguo) |
+| `design.md` | Plan | Arquitetura, modelos, contratos |
+| `impact.md` | Plan | Arquivos afetados, riscos, regressão |
+| `tasks.md` | Plan | Checklist numerado (⚠️ = alto risco) |
+| `journal.md` | Implement | Diário vivo: desvios, erros+soluções, pedidos extras |
+| `reflect.md` | Reflect | Decisões + diff aplicado no `.claude/` |
+
+## Ciclo
+
+- `/spec [feature]` → **Plan**: design + impact + tasks com gates de aprovação
+- `/spec-implement [feature]` → **Implement**: executa tasks, mantém `journal.md` vivo
+- `/spec-reflect [feature]` → **Reflect**: consolida aprendizado em skills/CLAUDE.md
+- `/spec-retro [feature|path]` → **Retro**: documenta feature já implementada sem spec
+
+> Antes de implementar feature relacionada a um spec existente, leia no mínimo
+> `design.md` + `impact.md` + `tasks.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,123 @@
+# StickerBot — Guia de Projeto (Claude Code)
+
+Bot de WhatsApp (Baileys v7 + TypeScript) que cria figurinhas e oferece monetização (VIP via MercadoPago PIX, anúncios) e utilidades de grupo (ex.: lista de pelada).
+
+- **Stack:** Node.js 20 + TypeScript; WhatsApp via `@whiskeysockets/baileys` v7; webserver Express.
+- **Persistência:** Drizzle ORM + MySQL (`mysql2`). Schema tipado em `src/db/schema.ts`.
+- **Frontend:** N/A (bot de chat + webhook).
+- **Como roda:** `npm start` (dev: `npm run dev`); build `npm run build` (tsc). Em produção roda em **Docker Compose** (ver skill `workflow-deploy`).
+
+---
+
+## 📚 Fonte canônica de conhecimento — `.claude/`
+
+| Pasta | Conteúdo | Como ativa |
+|---|---|---|
+| `.claude/skills/` | Skills passivas: horizontais (`clean-code`, `safe-refactoring`, `quality-assurance`) + always-on (`rule-project-core`) + por módulo (`workflow-database`, `workflow-commands`, `workflow-deploy`) + `spec-workflow` | Carregadas automaticamente quando a `description` matcha o contexto |
+| `.claude/agents/` | Personas: `orchestrator`, `architect`, `backend-specialist` | Subagentes via tool `Agent` (`subagent_type`) |
+| `.claude/commands/` | Slash commands: `/spec`, `/spec-implement`, `/spec-reflect`, `/spec-retro` | Digitando `/spec*` |
+| `.specs/` | Specs ativos (design/impact/tasks/journal/reflect) | Gerenciado pela skill `spec-workflow` |
+
+---
+
+## ⭐ Regra de Ouro — Roteamento
+
+Antes de tocar código, identifique o domínio e use a skill/persona certa:
+
+| Tarefa envolve | Use subagent | Skills principais |
+|---|---|---|
+| Decisão estrutural / prevenir monólito | `architect` | `safe-refactoring`, `rule-project-core` |
+| Comando novo, handler, lógica, persistência | `backend-specialist` | `workflow-commands`, `workflow-database`, `clean-code` |
+| Banco / schema / migração | `backend-specialist` | `workflow-database`, `rule-project-core` |
+| Deploy / produção / Docker | `backend-specialist` | `workflow-deploy` |
+| Multi-domínio / planejamento | `orchestrator` | `spec-workflow`, `quality-assurance` |
+
+Para tarefas complexas/ambíguas: **pare e pergunte** — mínimo 3 perguntas estratégicas antes de codificar (Socratic Gate).
+
+---
+
+## ⚖️ Leis Always-On (resumo)
+
+> Detalhes completos na skill [`rule-project-core`](.claude/skills/rule-project-core/SKILL.md), que carrega quando o assunto surge.
+
+- **Banco/migração:** Drizzle + MySQL, **sem framework de migração** — `initializeDB` só faz `CREATE TABLE IF NOT EXISTS`. Coluna nova em tabela existente → helper idempotente `ensureColumn` (via `information_schema`). Atualize sempre `schema.ts` + o `CREATE TABLE` em `db.ts`.
+- **Comandos/permissão:** auto-loader (`handlers/text.ts`); `checkCommand` no início. `onlyAdmin` = admin do **grupo**; `onlyBotAdmin` = operador do bot. Multi-grupo → gateie no admin do grupo.
+- **Concorrência:** handlers fire-and-forget (`void ...`) rodam concorrentes em rajadas — reserve estado em memória de forma **síncrona antes do `await`**; nunca deixe exceção vazar.
+- **Destrutivo em prod:** `DROP`/delete em massa → **backup antes** (`mysqldump`).
+- **Config em runtime:** tabela `Settings` + cache em memória (seed = ENV); hot path lê o cache, não o banco.
+- **Estilo:** sem `;`, aspas simples, max-len 124. Type-check confiável = `npm run build` (tsc) no build Docker (não há tsc local garantido).
+
+---
+
+## 🗄️ Estrutura macro
+
+```
+src/
+├─ bot.ts            # entry-point: conexão WA, webserver Express, dispatch de mensagens
+├─ config.ts         # objeto `bot` (config env-driven) + endpoints externos
+├─ commands/         # 1 arquivo = 1 comando (auto-loaded por handlers/text.ts)
+├─ handlers/         # db (Drizzle), text (dispatcher), sticker, ads, lists, community,
+│                    #   reaction, senderUsage, logger, emojiMix, fileUploader, memegen...
+├─ db/schema.ts      # schema Drizzle (fonte da verdade dos tipos)
+├─ scripts/          # migrate-db (SQLite → MySQL, one-off)
+├─ utils/            # baileysHelper, misc (spintax/getRandomItemFromArray), commandValidator,
+│                    #   emojis, colors, store
+└─ types/            # Command, Message, etc.
+```
+
+### Modelos/entidades (tabelas)
+- **Core:** `Usage` (contadores), `Vips` (assinaturas), `Banned` (banidos).
+- **Features:** `Ads` (anúncios) + `Settings` (config runtime key/value), `Lists` + `ListEntries` (listas/pelada).
+
+### Entry-points
+- **Comandos** via prefixos `! / @ # .` — arquivos em `src/commands/`, carregados automaticamente.
+- **Webserver Express** (porta interna 3000) — webhooks (ex.: MercadoPago).
+- **Eventos Baileys** em `bot.ts` (`messages.upsert`, `call`, `connection.update`).
+
+---
+
+## 🧭 Skills de referência profunda
+
+| Domínio | Skill |
+|---|---|
+| Leis fundamentais do projeto | `rule-project-core` |
+| Banco: Drizzle, schema, migração idempotente | `workflow-database` |
+| Criar/editar comando (auto-loader, permissões, helpers) | `workflow-commands` |
+| Deploy: Docker Compose + pscp/plink em produção | `workflow-deploy` |
+| Código limpo | `clean-code` |
+| Refatoração / quebra de monólito | `safe-refactoring` |
+| Quality gates / checklist de entrega | `quality-assurance` |
+| Spec-Driven Development (Plan/Implement/Reflect/Retro) | `spec-workflow` |
+
+---
+
+## 📋 Specs em andamento
+
+Specs ativos em `.specs/<feature>/` (até 5 arquivos). **Antes de implementar feature relacionada, leia design+impact+tasks.** Ciclo:
+- `/spec` → Plan · `/spec-implement` → Implement · `/spec-reflect` → Reflect · `/spec-retro` → documentar feature existente
+
+---
+
+## ✅ Checklist de entrega
+
+**Antes de implementar:** verifiquei `rule-project-core` + a `workflow-*` da área? Roteei pro especialista? Apliquei o Socratic Gate se ambíguo?
+
+**Durante:**
+- [ ] Mudou schema? Atualizei `schema.ts` + `CREATE TABLE` em `db.ts` + `ensureColumn` se a tabela já existe em prod?
+- [ ] Comando admin gateado no nível certo (grupo vs bot)?
+- [ ] Handler fire-and-forget: estado em memória reservado de forma síncrona? `try/catch` interno?
+- [ ] Operação destrutiva em prod tem backup antes?
+
+**Entrega:**
+- [ ] `npm run build` (tsc) passa no Docker? Lint ok?
+- [ ] Verifiquei o comportamento (não só compila)?
+- [ ] Sem código morto / scripts temporários soltos na raiz?
+
+---
+
+## 🧹 Convenções de trabalho
+
+- **Analisar o código existente antes de codificar** — trocar cego quebra fluxo.
+- **Raiz limpa**: scripts de debug/temp não ficam soltos na raiz (o `COPY . .` do Docker os arrastaria pro build).
+- **Reaproveitar helpers** de `utils/baileysHelper.ts` e `utils/misc.ts` em vez de reinventar.
+- Time fala **pt-BR**; mensagens ao usuário final em português.


### PR DESCRIPTION
## Resumo

Adiciona o ecossistema de conhecimento `.claude/` ao repositório: implementa **Spec-Driven Development** e captura o conhecimento do projeto para o Claude Code (e devs humanos) usarem sem reler tudo a cada sessão.

> Baseado no kit `bootstrap-claude-project`, adaptado ao StickerBot (sem frontend). **Só documentação/config — não altera código de produção.**

## O que entra

**Spec-Driven (motor):**
- `.claude/skills/spec-workflow/` — Plan → Implement → Reflect + Modo Retroativo
- `.claude/commands/` — `/spec`, `/spec-implement`, `/spec-reflect`, `/spec-retro`
- `.specs/` — onde os specs ativos vivem (design/impact/tasks/journal/reflect)

**Conhecimento do StickerBot:**
- `CLAUDE.md` — guia canônico (stack, módulos, roteamento por especialista, leis always-on, tabela de skills, checklist de entrega)
- `rule-project-core` — leis always-on reais: Drizzle/MySQL **sem framework de migração** (→ `ensureColumn`), auto-loader de comandos, permissão **admin-do-grupo vs admin-do-bot**, concorrência **fire-and-forget** (estado reservado antes do `await`), config em runtime (Settings + cache), backup antes de operação destrutiva
- `workflow-database`, `workflow-commands`, `workflow-deploy` — skills profundas por domínio

**Suporte:**
- skills horizontais `clean-code`, `safe-refactoring`, `quality-assurance`
- agentes `orchestrator`, `architect`, `backend-specialist`
- `.gitignore` do `.claude/settings.local.json` (config local da máquina)

## Notas

- Nenhum segredo commitado — host/credenciais de deploy ficam genéricos no `workflow-deploy` (repo é público).
- Absorve e amplia a skill `create_command` que existia em `.agents/` (a antiga pode ser removida).
- As skills carregam automaticamente via `description` no frontmatter; os comandos `/spec*` ficam disponíveis ao digitar.
